### PR TITLE
Use ignore-walk package to implement .homeyignore

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -673,7 +673,7 @@ class App {
   async _getPackFileEntries(prunePaths) {
     const walker = new ignoreWalk.Walker({
       path: this.path,
-      ignoreFiles: [ '.homeyignore', '' ],
+      ignoreFiles: [ '.homeyignore', '' ], // Empty string is workaround for adding default ignore rules
       includeEmpty: true,
       follow: true
     });

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -23,6 +23,7 @@ const inquirer = require('inquirer');
 const tmp = require('tmp-promise');
 const tar = require('tar-fs');
 const semver = require('semver');
+const ignoreWalk = require('ignore-walk');
 const gitIgnoreParser = require('gitignore-parser');
 const { monitorCtrlC } = require('monitorctrlc');
 const fse = require('fs-extra');
@@ -613,9 +614,9 @@ class App {
   }
 
   /**
-   * Method performs a npm prune dry run. It reads the generated JSON and based on that builds a Set of paths that need
-   * to be ignored during the tar process. If anything goes wrong, an empty Set is returned (hence no paths will be pruned).
-   * @returns {Promise<Set<String>>}
+   * Method performs a npm prune dry run. It reads the generated JSON and based on that builds an array of paths that need
+   * to be ignored during the tar process. If anything goes wrong, an empty array is returned (hence no paths will be pruned).
+   * @returns {Promise<String[]>}
    * @private
    */
   async _getPrunePaths() {
@@ -631,58 +632,14 @@ class App {
     return tmp.file().then( async o => {
 
       let tmpPath = o.path;
-      let homeyIgnore;
 
-      try {
-        let homeyIgnoreContents = await readFileAsync( path.join( this.path, '.homeyignore'), 'utf8' );
-        homeyIgnore = gitIgnoreParser.compile( homeyIgnoreContents );
-      } catch( err ){}
-
-      // Get npm prune paths
+      // Get list of files to pack, excluding npm prune paths and files in .homeyignore
       const prunePaths = await this._getPrunePaths();
+      const fileEntries = await this._getPackFileEntries(prunePaths);
 
-			let tarOpts = {
-				ignore: (name) => {
 
-					// ignore env.json
-					if( name === path.join( this.path, 'env.json' ) ) return true;
-
-          // ignore dotfiles (.git, .gitignore, .mysecretporncollection etc.)
-          if( path.basename(name).charAt(0) === '.' ) return true;
-
-          // Check if file is a node_module file, then check if it needs to be pruned
-          if (prunePaths.size > 0 && name.startsWith(path.join(this.path, 'node_modules')) && prunePaths.has(name)) return true;
-
-          /*
-          // ignore dependencies not in the production list
-          if( productionPackages !== null ) {
-					  const nodeModulesPath = path.join(this.path, 'node_modules');
-					  if( name === nodeModulesPath ) return false;
-
-            if (name.includes(nodeModulesPath)) {
-              let found = false;
-              for (let i = 0; i < productionPackages.length; i++) {
-                const productionPackage = productionPackages[i];
-                if (name.indexOf(productionPackage) === 0) {
-                  found = true;
-                  break;
-                }
-              }
-              if (!found) {
-                Log(colors.grey(` — Skipping ${name.replace(this.path, '')}`));
-                return true;
-              }
-            }
-          }
-          */
-
-          // ignore .homeyignore files
-          if( homeyIgnore ) {
-            return homeyIgnore.denies( name.replace(this.path, '') );
-          }
-
-          return false;
-        },
+      let tarOpts = {
+        entries: fileEntries,
         dereference: true
       };
 
@@ -711,7 +668,26 @@ class App {
       });
 
 		})
-	}
+  }
+  
+  async _getPackFileEntries(prunePaths) {
+    const walker = new ignoreWalk.Walker({
+      path: this.path,
+      ignoreFiles: [ '.homeyignore', '' ],
+      includeEmpty: true,
+      follow: true
+    });
+
+    // Add default ignore rules for dotfiles, env.json and npm prune paths
+    const ignoreRules = ['.*', 'env.json', ...prunePaths];
+    walker.onReadIgnoreFile('', ignoreRules.join('\r\n'), () => {});
+
+    const fileEntries = await new Promise((resolve, reject) => {
+      walker.on('done', resolve).on('error', reject).start();
+    });
+
+    return fileEntries;
+  }
 
   /**
    * Check if the current folder has a valid app.json.

--- a/lib/Modules/NpmCommands.js
+++ b/lib/Modules/NpmCommands.js
@@ -2,6 +2,7 @@
 
 const util = require('util');
 const _path = require('path');
+const upath = require('upath');
 const fse = require('fs-extra');
 const colors = require('colors');
 const npm = require('npm-programmatic');
@@ -70,26 +71,26 @@ class NpmCommands {
   }
 
   /**
-   * Execute npm prune and parse the JSON response. Pick the required properties and return a Set of paths to be pruned.
+   * Execute npm prune and parse the JSON response. Pick the required properties and return an array of paths to be pruned.
    * @param {string} path
-   * @returns {Promise<Set<string>>}
+   * @returns {Promise<string[]>}
    */
   static async getPrunePaths({ path }) {
     const npmInstalled = await NpmCommands.isNpmInstalled();
     if (!npmInstalled) {
       Log(colors.red('✖ Could not execute npm prune, please install npm globally'));
-      return new Set([]); // Return empty set to be safe
+      return []; // Return empty array to be safe
     }
 
     try {
       // Perform prune dry run and parse the JSON response
       const { stdout } = await exec(`npm prune --production --dry-run --json`, { cwd: path });
       const prunePathsJson = JSON.parse(stdout);
-      const prunePaths = prunePathsJson.removed.map(pruneObject => _path.resolve(_path.join(path, pruneObject.path)));
-      return new Set(prunePaths);
+      const prunePaths = prunePathsJson.removed.map(pruneObject => upath.normalize(pruneObject.path) + upath.sep);
+      return prunePaths;
     } catch (err) {
       Log(colors.red('✖ Error occurred during npm prune', err));
-      return new Set([]);
+      return [];
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homey",
-  "version": "2.1.0",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -647,6 +647,14 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "image-size": {
@@ -1630,6 +1638,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
     },
     "update-notifier": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "^5.0.0",
     "gitignore-parser": "0.0.2",
     "homey-lib": "2.4.5",
+    "ignore-walk": "^3.0.3",
     "ini": "^1.3.5",
     "inquirer": "^5.1.0",
     "monitorctrlc": "^2.0.1",
@@ -48,6 +49,7 @@
     "tar-fs": "^1.16.0",
     "tmp-promise": "^1.0.4",
     "underscore": "^1.8.3",
+    "upath": "^1.2.0",
     "update-notifier": "^2.3.0",
     "yargs": "^11.0.0"
   }


### PR DESCRIPTION
This is a reworked version of https://github.com/athombv/node-athom-cli/pull/152, which includes support for pruning dev dependencies.

The previously used package gitignore-parser actually showed very different behavior from actual .gitignore files. See issue https://github.com/athombv/node-athom-cli/issues/151 for details on this.

I had to use a bit of a trick to include some default ignore rules, for dotfiles, `env.json`, etc.
Because of this, I also changed the output of `_getPrunePaths` a little.

Pro tip:
Since this implementation works recursively like .gitignore does, npm packages like `homey-meshdriver` could even include their own .homeyignore file, which makes sure that some unneeded things do not included in store apps.