### PR TITLE
fix: deprecated buffer constructor usage

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -118,7 +118,7 @@ class App {
       }).then( stdCache => {
         stdCache
           .map(std => {
-            std.chunk = new Buffer(std.chunk);
+            std.chunk = Buffer.from(std.chunk);
             return std;
           })
           .forEach(this._onStd.bind(this));


### PR DESCRIPTION
Fixes buffer constructor deprecation warning when running `homey`
```
(node:1536) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
