### PR TITLE
[PoC] Add exit code for homey app validate command

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -67,6 +67,13 @@ class App {
   }
 
   async validate({ level = 'debug' } = {}) {
+    const result = await this._validate({ level });
+    if (result !== true) {
+      process.exit(1);
+    }
+  }
+
+  async _validate({ level = 'debug' } = {}) {
     Log(colors.green('✓ Validating app...'));
 
     try {
@@ -85,7 +92,7 @@ class App {
     Log(colors.green('✓ Building app...'));
     await this.preprocess();
 
-    let valid = await this.validate();
+    let valid = await this._validate();
     if( valid !== true ) throw new Error('The app is not valid, please fix the validation issues first.');
 
     Log(colors.green('✓ App built successfully'));
@@ -145,7 +152,7 @@ class App {
       await this.preprocess();
     }
 
-    let valid = await this.validate();
+    let valid = await this._validate();
     if( valid !== true ) throw new Error('Not installing, please fix the validation issues first');
 
     let activeHomey = await AthomApi.getActiveHomey();
@@ -283,7 +290,7 @@ class App {
       }
     }
 
-    const valid = await this.validate({ level: 'publish' });
+    const valid = await this._validate({ level: 'publish' });
     if( valid !== true ) throw new Error('The app is not valid, please fix the validation issues first.');
 
     const env = await this._getEnv();


### PR DESCRIPTION
Hello Athom team 👋 

`homey app validate` command doesn't return correct exit code in case of validation errors.
It's always `0`:
```
➜  com.gree git:(master) ✗ ../node-homey/bin/homey.js app validate --level publish  
✓ Pre-processing app...
✓ Validating app...
✖ Homey App did not validate against level `publish`:
[
    {
        "keyword": "required",
        "dataPath": "",
        "schemaPath": "#/required",
        "params": {
            "missingProperty": "images"
        },
        "message": "should have required property 'images'"
    }
]
➜  com.gree git:(master) ✗ echo $?
0
```

It would be nice to get an error exit code in case of validation was not passed.

I've prepared this PoC PR. Please let me know if you would like to have it in a different way. I'll prepare changes. Or feel free to rework it 🚀 