### PR TITLE
feat: check for homey-zigbeedriver peer dependency zigbee-clusters

### DIFF
--- a/lib/AppPluginZigbee/index.js
+++ b/lib/AppPluginZigbee/index.js
@@ -26,16 +26,37 @@ class AppPluginZigbee extends AppPlugin {
 	async run() {
     const appJson = await fse.readJSON(this._app._appJsonPath);
     if (appJson.sdk === 3) {
-      return NpmCommands.install({ save: true }, {
-        id: 'homey-zigbeedriver',
-        version: this._options.version,
-      });
+      return NpmCommands.install({ save: true }, { id: 'homey-zigbeedriver' })
+        .then(() => {
+          // Check if homey-zigbeedriver has zigbee-clusters as peerDependency listed, in that
+          // case install the peerDependency's version
+          const zigbeeClustersPeerDepVersion = this.getPeerDependencyVersion('homey-zigbeedriver', 'zigbee-clusters')
+          if (typeof zigbeeClustersPeerDepVersion === 'string') {
+            return NpmCommands.install({ save: true }, {
+              id: 'zigbee-clusters',
+              version: zigbeeClustersPeerDepVersion,
+            });
+          }
+        });
     }
     return NpmCommands.install({ save: true }, {
       id: 'homey-meshdriver',
       version: this._options.version,
     });
 	}
+
+  /**
+   * Returns version of listed peer dependency
+   * @param peerDependency
+   * @returns {null|string}
+   */
+	getPeerDependencyVersion(packageName, peerDependency) {
+    try {
+      return require( path.join( this._app.appPath, 'node_modules', packageName, 'package.json' )).peerDependencies[peerDependency];
+    } catch (error) {
+      return null; // package probably not installed
+    }
+  }
 
 	static createDriverQuestions() {
 		return [


### PR DESCRIPTION
In a future update homey-zigbeedriver will list zigbee-clusters as peer dependency instead of regular dependency. This commit ensures that the peer dependency is always installed (hence a compatible version).