### PR TITLE
feat: check for homey-zigbeedriver peer dependency zigbee-clusters #minor

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -511,14 +511,14 @@ class App {
           if (updatedChangelog) {
             await this._git.commitFiles({
               files: commitFiles,
-              message: `Bumps version to v${appVersion}`,
+              message: `Bump version to v${appVersion}`,
               description: `Changelog: ${changelog['en']}`,
             });
             Log(colors.green(`✓ Committed ${commitFiles.map(i => i.replace(`${this.path}/`, '')).join(', and ')} with version bump`));
           } else {
             await this._git.commitFiles({
               files: commitFiles,
-              message: `Bumps version to v${appVersion}`,
+              message: `Bump version to v${appVersion}`,
             });
             Log(colors.green(`✓ Committed ${commitFiles.map(i => i.replace(`${this.path}/`, '')).join(', and ')} with version bump`));
           }


### PR DESCRIPTION
Additionally, bumps lodash from 4.17.15 to 4.17.19.