### PR TITLE
feat: update templates for sdk v3

### DIFF
--- a/assets/templates/app/app.js
+++ b/assets/templates/app/app.js
@@ -3,11 +3,12 @@
 const Homey = require('homey');
 
 class MyApp extends Homey.App {
-	
-	onInit() {
-		this.log('MyApp is running...');
-	}
-	
+  /**
+   * onInit is called when the app is initialized.
+   */
+  async onInit() {
+    this.log('MyApp has been initialized');
+  }
 }
 
 module.exports = MyApp;

--- a/assets/templates/app/drivers/device.js
+++ b/assets/templates/app/drivers/device.js
@@ -31,7 +31,7 @@ class MyDevice extends Homey.Device {
 
   /**
    * onRenamed is called when the user updates the device's name.
-   * This method can be used this to synchronize the name to the device or bridge.
+   * This method can be used this to synchronise the name to the device.
    * @param {string} name The new name
    */
   onRenamed(name) {

--- a/assets/templates/app/drivers/device.js
+++ b/assets/templates/app/drivers/device.js
@@ -3,11 +3,47 @@
 const Homey = require('homey');
 
 class MyDevice extends Homey.Device {
-	
-	onInit() {
-		this.log('MyDevice has been inited');
-	}
-	
+  /**
+   * onInit is called when the device is initialized.
+   */
+  async onInit() {
+    this.log('MyDevice has been initialized');
+  }
+
+  /**
+   * onAdded is called when the user adds the device, called just after pairing.
+   */
+  onAdded() {
+    this.log('MyDevice has been added');
+  }
+
+  /**
+   * onSettings is called when the user updates the device's settings.
+   * @param {object} event the onSettings event data
+   * @param {object} event.oldSettings The old settings object
+   * @param {object} event.newSettings The new settings object
+   * @param {string[]} event.changedKeys An array of keys changed since the previous version
+   * @returns {Promise<string|void>} return a custom message that will be displayed
+   */
+  async onSettings({ oldSettings, newSettings, changedKeys }) {
+    this.log('MyDevice settings where changed');
+  }
+
+  /**
+   * onRenamed is called when the user updates the device's name.
+   * This method can be used this to synchronize the name to the device or bridge.
+   * @param {string} name The new name
+   */
+  onRenamed(name) {
+    this.log('MyDevice was renamed');
+  }
+
+  /**
+   * onDeleted is called when the user deleted the device.
+   */
+  onDeleted() {
+    this.log('MyDevice has been deleted');
+  }
 }
 
 module.exports = MyDevice;

--- a/assets/templates/app/drivers/device.js
+++ b/assets/templates/app/drivers/device.js
@@ -13,7 +13,7 @@ class MyDevice extends Homey.Device {
   /**
    * onAdded is called when the user adds the device, called just after pairing.
    */
-  onAdded() {
+  async onAdded() {
     this.log('MyDevice has been added');
   }
 
@@ -34,14 +34,14 @@ class MyDevice extends Homey.Device {
    * This method can be used this to synchronise the name to the device.
    * @param {string} name The new name
    */
-  onRenamed(name) {
+  async onRenamed(name) {
     this.log('MyDevice was renamed');
   }
 
   /**
    * onDeleted is called when the user deleted the device.
    */
-  onDeleted() {
+  async onDeleted() {
     this.log('MyDevice has been deleted');
   }
 }

--- a/assets/templates/app/drivers/driver.js
+++ b/assets/templates/app/drivers/driver.js
@@ -3,11 +3,31 @@
 const Homey = require('homey');
 
 class MyDriver extends Homey.Driver {
-	
-	onInit() {
-		this.log('MyDriver has been inited');
-	}
-	
+  /**
+   * onInit is called when the driver is initialized.
+   */
+  async onInit() {
+    this.log('MyDriver has been initialized');
+  }
+
+  /**
+   * onPairListDevices is called when a user is adding a device and the 'list_devices' view is called.
+   * This should return an array with the data of devices that are available for pairing.
+   */
+  async onPairListDevices() {
+    return [
+      // Example device data, note that `store` is optional
+      // {
+      //   name: 'My Device',
+      //   data: {
+      //     id: 'my-device',
+      //   },
+      //   store: {
+      //     address: '127.0.0.1',
+      //   },
+      // },
+    ];
+  }
 }
 
 module.exports = MyDriver;

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1976,7 +1976,7 @@ class App {
       id: answers.id,
       version: answers.version,
       compatibility: answers.compatibility,
-      sdk: 2,
+      sdk: 3,
       name: localizedProperties.name,
       description: localizedProperties.description,
       category: [ answers.category ],


### PR DESCRIPTION
This PR adds all overridable methods to the `app.js`, `driver.js` and `device.js` templates with some comments that explain the purpose of the methods.
I also updated the default `app.json` to set the SDK version to `3`.
I will follow up with a PR that enables homey-compose by default.