### PR TITLE
feat: create .homeycompose/app.json

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -2029,6 +2029,10 @@ class App {
       }
     }
 
+    if (answers.compose) {
+      await writeFileAsync( path.join(appPath, '.homeycompose', 'app.json'), JSON.stringify(appJson, false, 2) );
+    }
+
 		await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(appJson, false, 2) );
 		await writeFileAsync( path.join(appPath, 'locales', 'en.json'), JSON.stringify({}, false, 2) );
 		await writeFileAsync( path.join(appPath, 'app.js'), '' );


### PR DESCRIPTION
writes `app.json` twice if homeycompose is enabled, once to `/.homeycompose/app.json` and once to `/app.json`