### PR TITLE
fix: deep clone settings templates to prevent mutation

### DIFF
--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -47,6 +47,8 @@ const readFileAsync = util.promisify( fs.readFile );
 const writeFileAsync = util.promisify( fs.writeFile );
 const copyFileAsync = util.promisify( fs.copyFile );
 
+const deepClone = object => JSON.parse(JSON.stringify(object));
+
 const FLOW_TYPES = [ 'triggers', 'conditions', 'actions' ];
 
 class AppPluginCompose extends AppPlugin {
@@ -138,7 +140,9 @@ class AppPluginCompose extends AppPlugin {
 
 					Object.assign(settingObj, {
 						id: settingObj.$id || templateId,
-						...settingTemplate,
+						// We need to deep clone the settings template to make sure replaceSpecialPropertiesRecursive
+						// doesn't mutate references shared by multiple extended settings
+						...deepClone(settingTemplate),
 						...settingObj,
 					});
 				}


### PR DESCRIPTION
This prevents `replaceSpecialPropertiesRecursive` from mutating the `"hint"` values for all settings at the same time.

See https://bugs.athom.com/youtrack/issue/SUP-2319

More context:

A settings template can be used with homey compose, this template might look like this:

**reportThreshold.json**

```json
{
  "value": 200,
  "label": {
    "en": "Report threshold",
    "nl": "Rapportage drempel"
  },
  "hint": {
    "en": "This parameter ({{zwaveParameterIndex}}) determines the minimum change in value before reporting changes to Homey.",
    "nl": "Deze parameter ({{zwaveParameterIndex}}) bepaalt de minimum verandering van de meetwaarde voordat deze naar Homey wordt gestuurd."
  },
  "zwave": {
    "index": 40,
    "size": 2
  },
  "attr": {
    "min": 0,
    "max": 32767
  },
  "type": "number"
}
```

Spreading we combine templates shallowly so our actual settings overwrite the properties in the template (`{ ...settingTemplate, ...settingsObj }`). But now the `"hint"` property is still a reference to the original object. So when a driver uses the same template multiple times the `"hint"` is shared between all of those.

`replaceSpecialPropertiesRecursive` mutates the values in `hint` to replace `"{{zwaveParameterIndex}}"` with the zwave setting index. It does this through `obj[key]` (where `obj` is the `hint` object and the `key` is `"en"` or `"nl"`) which means it will mutate the object coming from the template which means that all settings using this template will receive that zwaveParameterIndex. 

Cloning the template makes sure this doesn't happen anymore.
Maybe we also want to clone the other template styles (although I'm not sure we mutate anything there)?
Additionally maybe we should use a more robust way of deep cloning?