### PR TITLE
fix: sdk v3 5.0.0 compatibility

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1948,7 +1948,7 @@ class App {
 				type: 'input',
 				name: 'compatibility',
 				message: 'What is your app\'s compatibility?',
-				default: '>=1.5.0',
+				default: '>=5.0.0',
 				validate: input => {
 					return semver.validRange(input) !== null;
 				}


### PR DESCRIPTION
Since we set the `sdk` property to `3` by default we probably should also set the compatibility to `>=5.0.0` otherwise the default app won't work.