### PR TITLE
fix: add note to compose app.json manifest

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -2032,10 +2032,10 @@ class App {
     if (answers.compose) {
       await writeFileAsync( path.join(appPath, '.homeycompose', 'app.json'), JSON.stringify(appJson, false, 2) );
 
-      const generatedAppManifestNote = {
-        "note": "This file is generated. Please edit .homeycompose/app.json instead."
+      const generatedAppManifestWarning = {
+        "_comment": "This file is generated. Please edit .homeycompose/app.json instead."
       };
-      await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(generatedAppManifestNote, false, 2) );
+      await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(generatedAppManifestWarning, false, 2) );
     } else {
       await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(appJson, false, 2) );
     }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -2031,9 +2031,15 @@ class App {
 
     if (answers.compose) {
       await writeFileAsync( path.join(appPath, '.homeycompose', 'app.json'), JSON.stringify(appJson, false, 2) );
+
+      const generatedAppManifestNote = {
+        "note": "This file is generated. Please edit .homeycompose/app.json instead."
+      };
+      await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(generatedAppManifestNote, false, 2) );
+    } else {
+      await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(appJson, false, 2) );
     }
 
-		await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(appJson, false, 2) );
 		await writeFileAsync( path.join(appPath, 'locales', 'en.json'), JSON.stringify({}, false, 2) );
 		await writeFileAsync( path.join(appPath, 'app.js'), '' );
 		await writeFileAsync( path.join(appPath, 'README.md'), `# ${appJson.name.en}\n\n${appJson.description.en}` );

--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -65,7 +65,7 @@ class AppPluginCompose extends AppPlugin {
 		try {
 			const appJSON = await this._getJsonFile(this._appJsonPathCompose);
 			this._appJson = {
-				"note": "This file is generated. Please edit .homeycompose/app.json instead.",
+				"_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
 				...appJSON,
 			};
 		} catch( err ) {

--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -63,7 +63,11 @@ class AppPluginCompose extends AppPlugin {
 
 		this._appJsonPathCompose = path.join( this._appPathCompose, 'app.json' );
 		try {
-			this._appJson = await this._getJsonFile(this._appJsonPathCompose);
+			const appJSON = await this._getJsonFile(this._appJsonPathCompose);
+			this._appJson = {
+				"note": "This file is generated. Please edit .homeycompose/app.json instead.",
+				...appJSON,
+			};
 		} catch( err ) {
 			if( err.code !== 'ENOENT' ) throw new Error(err);
 		}


### PR DESCRIPTION
This adds a note to `app.json` when it is generated by homey compose to warn developers to not edit the "normal" `app.json`.