### PR TITLE
fix: allow reconnect

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -132,10 +132,15 @@ class App {
       }).catch(err => {
         Log(colors.red('✖', err.message || err.toString()));
       })
-    activeHomey.devkit.on('disconnect', () => {
-      Log(colors.red(`✖ Connection has been lost, exiting...`));
-      process.exit();
-    })
+
+      activeHomey.devkit.on('disconnect', () => {
+        Log(colors.red(`✖ Connection has been lost, attempting to reconnect...`));
+
+        // reconnect event isn't forwarded from athom api
+        activeHomey.devkit.once('connect', () => {
+          Log(colors.green(`✓ Reconnected, some app logs may have been lost`));
+        })
+      })
 
     monitorCtrlC(this._onCtrlC.bind(this));
   }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -138,7 +138,7 @@ class App {
 
         // reconnect event isn't forwarded from athom api
         activeHomey.devkit.once('connect', () => {
-          Log(colors.green(`✓ Reconnected, some app logs may have been lost`));
+          Log(colors.green(`✓ Connection restored, some logs might be missing`));
         })
       })
 


### PR DESCRIPTION
This PR removes the `process.exit()` on a disconnect from ManagerDevkit.
Losing the connection is still an issue but now it will at least try to reconnect.

What this looks like in practice:
![reconnect](https://user-images.githubusercontent.com/5736783/96448189-4ec2cd00-1213-11eb-81c4-77658138566c.PNG)
