### PR TITLE
fix: undefined card args

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -963,13 +963,13 @@ class App {
                         removeThisFlow = true;
                       }
                     }
-
-                    if( removeThisFlow ) {
-                      appFlowJson[type] = appFlowJson[type].filter(filterFlowCard => {
-                        return filterFlowCard !== flowCard;
-                      });
-                    }
                   });
+
+                  if( removeThisFlow ) {
+                    appFlowJson[type] = appFlowJson[type].filter(filterFlowCard => {
+                      return filterFlowCard !== flowCard;
+                    });
+                  }
                 });
               });
 

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -943,6 +943,8 @@ class App {
                 if( !appFlowJson[type] ) return // Return when this type is not found in the JSON.
 
                 appFlowJson[type].forEach( flowCard => {
+                  if (!flowCard.args) return; // Return when this flow card has no args.
+
                   let removeThisFlow = false;
 
                   flowCard.args.forEach( (argument, index, flowCardArgs) => {


### PR DESCRIPTION
From https://athomcommunity.slack.com/archives/C04SUGZ9E/p1604955941191500

I believe args are optional so we should check whether they are present before attempting to loop over them.

I also noticed that the `removeThisFlow` was part of the loop over `args` but I think it's fine if we do that only once after the loop.