### PR TITLE
fix: check npm version in prune paths

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -679,12 +679,19 @@ class App {
    * @private
    */
   async _getPrunePaths() {
-    // Check if npm is available then start prune dry-run
-    const npmInstalled = await NpmCommands.isNpmInstalled();
-    if (npmInstalled) {
-      Log(colors.green('✓ Pruning dev dependencies...'));
-      return NpmCommands.getPrunePaths({path: this.path});
+    if (await NpmCommands.isNpmInstalled() === false) {
+      return;
     }
+
+    // Check if npm is available then start prune dry-run
+    const npmVersion = await NpmCommands.getNpmVersion();
+
+    if (semver.lt('7.0.0', npmVersion)) {
+      throw new Error('The homey CLI does not support NPM version 7 yet, please install NPM version 6.');
+    }
+
+    Log(colors.green('✓ Pruning dev dependencies...'));
+    return NpmCommands.getPrunePaths({path: this.path});
   }
 
   async _getPackStream() {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -686,7 +686,7 @@ class App {
     // Check if npm is available then start prune dry-run
     const npmVersion = await NpmCommands.getNpmVersion();
 
-    if (semver.lt('7.0.0', npmVersion)) {
+    if (semver.lte('7.0.0', npmVersion)) {
       throw new Error('The homey CLI does not support NPM version 7 yet, please install NPM version 6.');
     }
 

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -687,7 +687,7 @@ class App {
     const npmVersion = await NpmCommands.getNpmVersion();
 
     if (semver.lte('7.0.0', npmVersion)) {
-      throw new Error('The homey CLI does not support NPM version 7 yet, please install NPM version 6.');
+      throw new Error('The Homey CLI does not support NPM version 7 yet, please install NPM version 6.');
     }
 
     Log(colors.green('✓ Pruning dev dependencies...'));

--- a/lib/Modules/NpmCommands.js
+++ b/lib/Modules/NpmCommands.js
@@ -17,7 +17,7 @@ class NpmCommands {
    */
   static async isNpmInstalled() {
     try {
-      NpmCommands.getNpmVersion();
+      await NpmCommands.getNpmVersion();
       return true;
     } catch (error) {
       return false;

--- a/lib/Modules/NpmCommands.js
+++ b/lib/Modules/NpmCommands.js
@@ -17,12 +17,21 @@ class NpmCommands {
    */
   static async isNpmInstalled() {
     try {
-      const { stdout, stderr } = await exec('npm --version');
-
-      return stdout ? true : false;
+      NpmCommands.getNpmVersion();
+      return true;
     } catch (error) {
       return false;
     }
+  }
+
+  static async getNpmVersion() {
+    const { stdout, stderr } = await exec('npm --version');
+
+    if (stderr || !stdout) {
+      throw new Error('Unable to read npm version.');
+    }
+
+    return stdout;
   }
 
   /**


### PR DESCRIPTION
This adds a new NPM command `getNpmVersion` and checks it before attempting to `getPrunePaths`.
This is a temporary fix to ensure a better developer experience (so please suggest a better error message).
An alternative fix may be to remove `getPrunePaths` but then we'd suddenly start shipping way bigger apps :(

We should come up with a strategy to be less dependent on npm (and specifically pruning dependencies since that no longer works as intended). I personally think something like https://github.com/vercel/nft would be great to pack only the required files, I experimented with it and it looks like it works but its remains difficult to detect missing dependencies.