### PR TITLE
Chore/cleanup manifest validation

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -39,7 +39,6 @@ const mkdirAsync = promisify( fs.mkdir );
 const readFileAsync = promisify( fs.readFile );
 const writeFileAsync = promisify( fs.writeFile );
 const copyFileAsync = promisify( fs.copyFile );
-const accessAsync = promisify( fs.access );
 const readDirAsync = promisify( fs.readdir );
 
 const GitCommands = require('../Modules/GitCommands');
@@ -52,7 +51,6 @@ class App {
 	constructor( appPath ) {
 		this.path = path.resolve(appPath);
 		this._app = new HomeyLibApp( this.path );
-    this._appJsonPath = path.join( this.path, 'app.json' );
     this._homeyComposePath = path.join(this.path, '.homeycompose');
 		this._exiting = false;
 		this._std = {};
@@ -617,38 +615,27 @@ class App {
   }
 
   async version(version) {
-    let appJsonPath;
+    let appJsonPath = path.join(this.path, 'app.json');
+
+    const composeAppJsonPath = path.join(this.path, '.homeycompose', 'app.json');
+    if (fs.existsSync(composeAppJsonPath)) {
+      appJsonPath = composeAppJsonPath;
+    }
+
     let appJson;
 
-    if( App.hasHomeyCompose({ appPath: this.path }) ) {
-        let appJsonComposePath = path.join(this.path, '.homeycompose', 'app.json');
-        let exists = false;
-        try {
-          await accessAsync(appJsonComposePath, fs.constants.R_OK | fs.constants.W_OK);
-          exists = true;
-        } catch( err ) {}
+    try {
+      appJson = await readFileAsync( appJsonPath, 'utf8' );
+      appJson = JSON.parse( appJson );
+    } catch( err ) {
+      if( err.code === 'ENOENT' )
+        throw new Error(`Could not find a valid Homey App at \`${this.path}\``);
 
-        if( exists ) {
-          appJsonPath = appJsonComposePath;
-        } else {
-          appJsonPath = path.join(this.path, 'app.json');
-        }
-      } else {
-        appJsonPath = path.join(this.path, 'app.json');
-      }
+      throw new Error(`Error in \`app.json\`:\n${err}`);
+    }
 
-      try {
-        appJson = await readFileAsync( appJsonPath, 'utf8' );
-        appJson = JSON.parse( appJson );
-      } catch( err ) {
-        if( err.code === 'ENOENT' )
-          throw new Error(`Could not find a valid Homey App at \`${this.path}\``);
-
-        throw new Error(`Error in \`app.json\`:\n${err}`);
-      }
-
-      if( semver.valid(version) ) {
-        appJson.version = version;
+    if( semver.valid(version) ) {
+      appJson.version = version;
     } else {
       if( !['minor', 'major', 'patch'].includes(version) )
         throw new Error('Invalid version. Must be either patch, minor or major.');
@@ -741,7 +728,7 @@ class App {
       await this.version(shouldUpdateVersionTo.version);
 
       // Check if only app.json or also .homeycompose/app.json needs to be committed
-      commitFiles.push(this._appJsonPath);
+      commitFiles.push(path.join(this.path, 'app.json'));
       if (await fse.exists(path.join(this._homeyComposePath, 'app.json'))) {
         commitFiles.push(path.join(this._homeyComposePath, 'app.json'));
       }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -615,38 +615,32 @@ class App {
   }
 
   async version(version) {
-    let appJsonPath = path.join(this.path, 'app.json');
+    // HACK: we want to get the "source" manifest, which means if Homey Compose is enabled
+    // we want to read from and write to the .homeycompose/app.json file.
+    // We trick `getManifest` to look into the wrong folder to read and validate the manifest.
+    const manifestFolder = App.hasHomeyCompose({ appPath: this.path })
+      ? path.join(this.path, '.homeycompose')
+      : this.path;
 
-    const composeAppJsonPath = path.join(this.path, '.homeycompose', 'app.json');
-    if (fs.existsSync(composeAppJsonPath)) {
-      appJsonPath = composeAppJsonPath;
-    }
+    const manifest = App.getManifest({ appPath: manifestFolder });
 
-    let appJson;
+    switch (true) {
+      case semver.valid(version):
+        manifest.version = version;
+        break;
 
-    try {
-      appJson = await readFileAsync( appJsonPath, 'utf8' );
-      appJson = JSON.parse( appJson );
-    } catch( err ) {
-      if( err.code === 'ENOENT' )
-        throw new Error(`Could not find a valid Homey App at \`${this.path}\``);
+      case ['minor', 'major', 'patch'].includes(version):
+        manifest.version = semver.inc(manifest.version, version);
+        break;
 
-      throw new Error(`Error in \`app.json\`:\n${err}`);
-    }
-
-    if( semver.valid(version) ) {
-      appJson.version = version;
-    } else {
-      if( !['minor', 'major', 'patch'].includes(version) )
+      default:
         throw new Error('Invalid version. Must be either patch, minor or major.');
-
-      appJson.version = semver.inc(appJson.version, version);
     }
 
-    await writeFileAsync( appJsonPath, JSON.stringify(appJson, false, 2) );
+    await writeFileAsync(path.join(manifestFolder, 'app.json'), JSON.stringify(manifest, false, 2));
     await this.build();
 
-    Log(colors.green(`✓ Updated app.json version to \`${appJson.version}\``));
+    Log(colors.green(`✓ Updated app.json version to \`${manifest.version}\``));
   }
 
   async publish() {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -50,7 +50,6 @@ class App {
 
 	constructor( appPath ) {
 		this.path = path.resolve(appPath);
-		this._app = new HomeyLibApp( this.path );
     this._homeyComposePath = path.join(this.path, '.homeycompose');
 		this._exiting = false;
 		this._std = {};
@@ -68,7 +67,8 @@ class App {
     Log(colors.green('✓ Validating app...'));
 
     try {
-      await this._app.validate({ level });
+      const validator = new HomeyLibApp(this.path);
+      await validator.validate({ level });
 
       Log(colors.green(`✓ Homey App validated successfully against level \`${level}\``));
       return true;

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -48,11 +48,11 @@ const FLOW_TYPES = [ 'triggers', 'conditions', 'actions' ];
 
 class App {
 
-	constructor( appPath ) {
-		this.path = path.resolve(appPath);
+  constructor( appPath ) {
+    this.path = path.resolve(appPath);
     this._homeyComposePath = path.join(this.path, '.homeycompose');
-		this._exiting = false;
-		this._std = {};
+    this._exiting = false;
+    this._std = {};
     this._git = new GitCommands(appPath);
   }
 
@@ -220,17 +220,17 @@ class App {
     // Download Image
     if (!process.env.HOMEY_APP_RUNNER_ID) {
       // Only pull periodically
-			let now = new Date();
-			let lastCheck = await Settings.get('dockerPullHomeyAppRunnerLastCheck');
-			if( lastCheck === null ) {
-				lastCheck = new Date(1970, 1, 1);
-			} else {
-				lastCheck = new Date(lastCheck);
-			}
-					
-			let hours = Math.abs(now - lastCheck) / 36e5;
-			if( hours > 12 ) {
-				await Settings.set('dockerPullHomeyAppRunnerLastCheck', now.toString());
+      let now = new Date();
+      let lastCheck = await Settings.get('dockerPullHomeyAppRunnerLastCheck');
+      if( lastCheck === null ) {
+        lastCheck = new Date(1970, 1, 1);
+      } else {
+        lastCheck = new Date(lastCheck);
+      }
+          
+      let hours = Math.abs(now - lastCheck) / 36e5;
+      if( hours > 12 ) {
+        await Settings.set('dockerPullHomeyAppRunnerLastCheck', now.toString());
 
         Log(colors.green(`✓ Downloading Docker Image...`));
         await new Promise((resolve, reject) => {
@@ -1040,7 +1040,7 @@ class App {
 
       });
 
-		})
+    })
   }
   
   async _getPackFileEntries(prunePaths) {
@@ -1263,7 +1263,7 @@ class App {
     return answers.switch_compose;
   }
 
-	async createDriver() {
+  async createDriver() {
     App.getManifest({ appPath: this.path });
 
     const { driverName } = await inquirer.prompt([
@@ -1353,31 +1353,31 @@ class App {
 
     if( !answers.confirm ) return;
 
-		let driverId = answers.id;
-		let driverPath = path.join( this.path, 'drivers', driverId );
-		let driverJson = {
-			id: driverId,
-			name: { en: driverName },
-			class: answers.class,
-			capabilities: answers.capabilities,
-			images: {
-				large: `/drivers/${driverId}/assets/images/large.png`,
-				small: `/drivers/${driverId}/assets/images/small.png`,
-			},
-		}
+    let driverId = answers.id;
+    let driverPath = path.join( this.path, 'drivers', driverId );
+    let driverJson = {
+      id: driverId,
+      name: { en: driverName },
+      class: answers.class,
+      capabilities: answers.capabilities,
+      images: {
+        large: `/drivers/${driverId}/assets/images/large.png`,
+        small: `/drivers/${driverId}/assets/images/small.png`,
+      },
+    }
 
-		await fse.ensureDir( driverPath );
-		await fse.ensureDir( path.join(driverPath, 'assets') );
-		await fse.ensureDir( path.join(driverPath, 'assets', 'images') );
+    await fse.ensureDir( driverPath );
+    await fse.ensureDir( path.join(driverPath, 'assets') );
+    await fse.ensureDir( path.join(driverPath, 'assets', 'images') );
 
     let templatePath = path.join(__dirname, '..', '..', 'assets', 'templates', 'app', 'drivers');
     await copyFileAsync( path.join(templatePath, 'driver.js'), path.join(driverPath, 'driver.js') );
     await copyFileAsync( path.join(templatePath, 'device.js'), path.join(driverPath, 'device.js') );
 
-		if( App.hasHomeyCompose({ appPath: this.path }) ) {
-			if( answers.createDiscovery === true ) {
-				await this.createDiscoveryStrategy();
-			}
+    if( App.hasHomeyCompose({ appPath: this.path }) ) {
+      if( answers.createDiscovery === true ) {
+        await this.createDiscoveryStrategy();
+      }
 
       if( driverJson.settings ) {
         let driverJsonSettings = driverJson.settings;
@@ -1503,7 +1503,7 @@ class App {
       driverFlowJson = await readFileAsync( flowPath, 'utf8' );
       driverFlowJson = JSON.parse( driverFlowJson );
     } catch( err ) {
-      if( err.code === 'ENOENT' )	{
+      if( err.code === 'ENOENT' ) {
         driverFlowJson = {}; // File not found so init empty JSON
       } else {
         throw new Error(`Error in \`driver.flow.compose.json.\`:\n${err}`);
@@ -1925,7 +1925,7 @@ class App {
             type: 'list',
             name: 'protocol',
             message: 'What is the protocol of your mDNS query?',
-            choices: [ "tcp", "udp"	]
+            choices: ["tcp", "udp"]
           },
           {
             type: 'input',
@@ -2198,16 +2198,16 @@ class App {
     };
     await writeFileAsync( path.join(appPath, 'app.json'), JSON.stringify(generatedAppManifestWarning, false, 2) );
 
-		await writeFileAsync( path.join(appPath, 'locales', 'en.json'), JSON.stringify({}, false, 2) );
-		await writeFileAsync( path.join(appPath, 'app.js'), '' );
-		await writeFileAsync( path.join(appPath, 'README.md'), `# ${appJson.name.en}\n\n${appJson.description.en}` );
-		await writeFileAsync( path.join(appPath, 'README.txt'), `${appJson.description.en}\n`);
+    await writeFileAsync( path.join(appPath, 'locales', 'en.json'), JSON.stringify({}, false, 2) );
+    await writeFileAsync( path.join(appPath, 'app.js'), '' );
+    await writeFileAsync( path.join(appPath, 'README.md'), `# ${appJson.name.en}\n\n${appJson.description.en}` );
+    await writeFileAsync( path.join(appPath, 'README.txt'), `${appJson.description.en}\n`);
 
-		// i18n pre-support
-		// TODO check if this works after creating i18n inquirer stuff
-		if( appJson.description.nl ) {
-			await writeFileAsync( path.join(appPath, 'README.nl.txt'), `${appJson.description.nl}\n`);
-		}
+    // i18n pre-support
+    // TODO check if this works after creating i18n inquirer stuff
+    if( appJson.description.nl ) {
+      await writeFileAsync( path.join(appPath, 'README.nl.txt'), `${appJson.description.nl}\n`);
+    }
 
     // copy files
     const templatePath = path.join(__dirname, '..', '..', 'assets', 'templates', 'app');

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -195,8 +195,7 @@ class App {
     let valid = await this._validate();
     if (valid !== true) throw new Error('Not installing, please fix the validation issues first');
 
-    // Get the App's Manifest
-    const manifest = await this._getAppJsonFromFolder(this.path);
+    const manifest = App.getManifest({ appPath: this.path });
 
     // Install the App
     Log(colors.green(`✓ Creating session...`));
@@ -608,14 +607,9 @@ class App {
   }
 
   async preprocess() {
+    App.getManifest({ appPath: this.path });
+
     Log(colors.green('✓ Pre-processing app...'));
-
-    const appJson = await this._getAppJsonFromFolder();
-    if (!appJson) {
-      throw new Error('This app.json is invalid!');
-    }
-
-    this._isValidAppJson(appJson);
 
     if (App.hasHomeyCompose({ appPath: this.path })) {
       await HomeyCompose.build({ appPath: this.path });
@@ -693,11 +687,11 @@ class App {
 
     const env = await this._getEnv();
 
-    const appJson = await fse.readJSON(this._appJsonPath);
     let {
       id: appId,
+      name: appName,
       version: appVersion,
-    } = appJson;
+    } = App.getManifest({ appPath: this.path });
 
     const versionBumpChoices = {
       patch: {
@@ -772,7 +766,7 @@ class App {
           {
             type: 'input',
             name: 'text',
-            message: `(Changelog) What's new in ${appJson.name.en} v${appVersion}?`,
+            message: `(Changelog) What's new in ${appName.en} v${appVersion}?`,
             validate: input => {
               return input.length > 3;
             }
@@ -1082,47 +1076,6 @@ class App {
   }
 
   /**
-   * Check if the current folder has a valid app.json.
-   * @returns : Parsed JSON object or Error if no app.json was found
-   * @private
-   */
-  async _getAppJsonFromFolder() {
-    const appJsonPath = path.join(this.path, 'app.json');
-    let appJson;
-
-    try {
-      appJson = await readFileAsync( appJsonPath, 'utf8' );
-      appJson = JSON.parse( appJson );
-    } catch( err ) {
-      if( err.code === 'ENOENT' )	throw new Error(`Could not find a valid Homey App at \`${this.path}\``);
-
-      throw new Error(`Error in \`app.json\`:\n${err}`);
-    }
-    return appJson;
-  }
-
-  /**
-   * Check if the parsed app.json contains the keys to be a valid Homey app.
-   * @param
-   * @returns {Boolean}
-   *  */
-  _isValidAppJson(appJson) {
-    if( appJson.hasOwnProperty('id') &&
-      appJson.hasOwnProperty('version') &&
-      appJson.hasOwnProperty('compatibility') &&
-      appJson.hasOwnProperty('name')
-    ) return true;
-
-    return false;
-  }
-
-  _validateAppJson(appJson) {
-    if( this._isValidAppJson(appJson) ) return;
-
-    throw new Error(`The found app.json does not contain the required properties for a valid Homey app!`);
-  }
-
-  /**
    * Function to get al drivers from the current path.
    * Returns: String array containing the driver id's.
    */
@@ -1155,8 +1108,7 @@ class App {
         throw new Error('Please commit changes first!');
     }
 
-    const appJson = await this._getAppJsonFromFolder( this.path );
-    this._validateAppJson( appJson );
+    const appJson = App.getManifest({ appPath: this.path });
 
     let drivers = await this._getDrivers();
     if( appJson.flow ) {
@@ -1325,10 +1277,7 @@ class App {
   }
 
 	async createDriver() {
-		const appJson = await this._getAppJsonFromFolder();
-		if (appJson) {
-			this._isValidAppJson(appJson);
-		} else return;
+    App.getManifest({ appPath: this.path });
 
     const { driverName } = await inquirer.prompt([
       {
@@ -1588,10 +1537,7 @@ class App {
   }
 
   async createFlowJson() {
-    const appJson = await this._getAppJsonFromFolder();
-    if( appJson ) {
-      this._validateAppJson(appJson);
-    }
+    App.getManifest({ appPath: this.path });
 
     if( App.hasHomeyCompose({ appPath: this.path }) === false ) {
       if( await this._askComposeMigration() ) {
@@ -1922,10 +1868,7 @@ class App {
   }
 
   async createDiscoveryStrategy() {
-    const appJson = await this._getAppJsonFromFolder();
-    if( appJson ) {
-      this._validateAppJson(appJson);
-    }
+    App.getManifest({ appPath: this.path });
 
     if( App.hasHomeyCompose({ appPath: this.path }) === false ) {
       if( await this._askComposeMigration() ) {
@@ -2332,6 +2275,26 @@ class App {
 
   static hasHomeyCompose({ appPath }) {
     return fs.existsSync(path.join(appPath, '.homeycompose'));
+  }
+
+  static getManifest({ appPath }) {
+    try {
+      const manifestPath = path.join(appPath, 'app.json');
+      const manifest = fse.readJSONSync(manifestPath);
+
+      if (
+        manifest.hasOwnProperty('id') === false ||
+        manifest.hasOwnProperty('version') === false ||
+        manifest.hasOwnProperty('compatibility') === false ||
+        manifest.hasOwnProperty('name') === false
+      ) {
+        throw new Error(`Found 'app.json' file does not contain the required properties for a valid Homey app!`);
+      }
+
+      return manifest;
+    } catch (error) {
+      throw new Error(`Could not find a valid Homey App at '${appPath}':\n${error.message}`);
+    }
   }
 
 }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1264,7 +1264,10 @@ class App {
   }
 
   async createDriver() {
-    App.getManifest({ appPath: this.path });
+    // Note: this checks that we are in a valid homey app folder (compose or legacy)
+    if (App.hasHomeyCompose({ appPath: this.path }) === false) {
+      App.getManifest({ appPath: this.path });
+    }
 
     const { driverName } = await inquirer.prompt([
       {
@@ -1855,9 +1858,10 @@ class App {
   }
 
   async createDiscoveryStrategy() {
-    App.getManifest({ appPath: this.path });
-
     if( App.hasHomeyCompose({ appPath: this.path }) === false ) {
+      // Note: this checks that we are in a valid homey app folder
+      App.getManifest({ appPath: this.path });
+
       if( await this._askComposeMigration() ) {
         await this.migrateToCompose();
       } else {


### PR DESCRIPTION
Last commit fixes: https://github.com/athombv/homey-apps-sdk-issues/issues/190

This contains some cleanup/fixes that I already did, this issue was related to the same code so I figured it would be fine to bundle.

`createDriver` had a bug, this code didn't do what it was intended to do

```js
if (appJson) {
  this._isValidAppJson(appJson);
} else return;
```

`_isValidAppJson` returns a boolean and doesn't throw...

However if someone selects the "create a discovery strategy" option that checks 

```js
if( appJson ) {
  this._validateAppJson(appJson);
}
```

Which throws `The found app.json does not contain the required properties for a valid Homey app!` if the app.json is not valid.

When generating a Homey Compose App we now create an "empty" app.json which means that check would fail.

This PR fixes this by checking `App.hasHomeyCompose()` first. If that is false we check `App.getManifest()` which gets and validates the "regular" app.json. Those combined checks should tell us that we are very likely inside a Homey App folder (and throw a decent error if we are not).
