### PR TITLE
Chore/cleanup create flow

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1533,6 +1533,19 @@ class App {
 
     const flowFolder = path.join(this.path, '.homeycompose', 'flow');
 
+    const { flowType } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'flowType',
+        message: 'What is the type of your Flow card?',
+        choices: [
+          { name: "Trigger (When)", value: "triggers" },
+          { name: "Condition (And)", value: "conditions" },
+          { name: "Action (Then)", value: "actions" },
+        ],
+      }
+    ]);
+
     const { flowTitle, flowHint } = await inquirer.prompt([
       {
         type: 'input',
@@ -1547,31 +1560,10 @@ class App {
       }
     ]);
 
-    let answers = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'type',
-        message: 'What is the type of your Flow card?',
-        choices: () => {
-          return [
-            {
-              name: "Trigger (When)",
-              value: "triggers"
-            },
-            {
-              name: "Condition (And)",
-              value: "conditions"
-            },
-            {
-              name: "Action (Then)",
-              value: "actions"
-            }
-          ]
-        }
-      },
+    const { flowId } = await inquirer.prompt([
       {
         type: 'input',
-        name: 'id',
+        name: 'flowId',
         message: 'What is the ID of your Flow Card?',
         default: () => {
           let name = flowTitle;
@@ -1805,8 +1797,8 @@ class App {
     if( !confirm ) return;
 
     let flowJson = {
-      type: answers.type,
-      id: answers.id,
+      type: flowType,
+      id: flowId,
       title: { en: flowTitle },
     }
 

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1531,8 +1531,6 @@ class App {
       }
     }
 
-    const flowFolder = path.join(this.path, '.homeycompose', 'flow');
-
     const { flowType } = await inquirer.prompt([
       {
         type: 'list',
@@ -1572,17 +1570,14 @@ class App {
           name = name.replace(/[^0-9a-zA-Z-_]+/g, '');
           return name;
         },
-        validate: async input => {
+        validate: input => {
           if( input.search(/^[a-zA-Z0-9-_]+$/) === -1 )
             throw new Error('Invalid characters: only use [a-zA-Z0-9-_]');
 
           // Check if the flow entry already exists in the .homeycompose/flow folder
-          if( await fse.exists( path.join(flowFolder, 'triggers', `${input}.json` ) ) ||
-            await fse.exists( path.join(flowFolder, 'conditions', `${input}.json` ) ) ||
-            await fse.exists( path.join(flowFolder, 'actions', `${input}.json` ) )
-          )
-
+          if (fs.existsSync(path.join(this.path, '.homeycompose', 'flow', flowType, `${input}.json`))) {
             throw new Error('Flow already exists!');
+          }
 
           return true;
         }
@@ -1616,46 +1611,17 @@ class App {
             type: 'list',
             name: 'type',
             message: 'What is the type of the argument?',
-            choices: () => {
-              return [
-                {
-                  name: "Text",
-                  value: "text"
-                },
-                {
-                  name: "Number",
-                  value: "number"
-                },
-                {
-                  name: "Autocomplete",
-                  value: "autocomplete"
-                },
-                {
-                  name: "Range",
-                  value: "range"
-                },
-                {
-                  name: "Date",
-                  value: "date"
-                },
-                {
-                  name: "Time",
-                  value: "time"
-                },
-                {
-                  name: "Dropdown",
-                  value: "dropdown"
-                },
-                {
-                  name: "Color",
-                  value: "color"
-                },
-                {
-                  name: "Droptoken",
-                  value: "droptoken"
-                }
-              ]
-            }
+            choices: [
+              { name: "Text", value: "text" },
+              { name: "Number", value: "number" },
+              { name: "Autocomplete", value: "autocomplete" },
+              { name: "Range", value: "range" },
+              { name: "Date", value: "date" },
+              { name: "Time", value: "time" },
+              { name: "Dropdown", value: "dropdown" },
+              { name: "Color", value: "color" },
+              { name: "Droptoken", value: "droptoken" },
+            ],
           },
           {
             type: 'input',
@@ -1727,26 +1693,12 @@ class App {
             type: 'list',
             name: 'type',
             message: 'What is the type of the token?',
-            choices: () => {
-              return [
-                {
-                  name: "Text",
-                  value: "string"
-                },
-                {
-                  name: "Number",
-                  value: "number"
-                },
-                {
-                  name: "Boolean",
-                  value: "boolean"
-                },
-                {
-                  name: "Image",
-                  value: "image"
-                }
-              ]
-            }
+            choices: [
+              { name: "Text", value: "string" },
+              { name: "Number", value: "number" },
+              { name: "Boolean", value: "boolean" },
+              { name: "Image", value: "image" },
+            ],
           },
           {
             type: 'input',

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1543,8 +1543,7 @@ class App {
       {
         type: 'input',
         name: 'flowHint',
-        message: 'What is the hint for your Flow Card',
-        validate: input => input.length > 0,
+        message: 'What is the hint for your Flow Card? (optional)',
       }
     ]);
 
@@ -1809,23 +1808,18 @@ class App {
       type: answers.type,
       id: answers.id,
       title: { en: flowTitle },
-      hint: { en: flowHint },
+    }
+
+    if (flowHint) {
+      flowJson.hint = { en: flowHint };
     }
 
     if( useArgs.using_arguments ) {
-      Object.assign(flowJson, flowJson,
-        {
-          args: flowArgs
-        }
-      );
+      flowJson.args = flowArgs;
     }
 
     if( useTokens.using_tokens ) {
-      Object.assign(flowJson, flowJson,
-        {
-          tokens: flowTokens
-        }
-      )
+      flowJson.tokens = flowTokens;
     }
 
     return flowJson;

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1521,10 +1521,10 @@ class App {
   }
 
   async createFlowJson() {
-    App.getManifest({ appPath: this.path });
+    if (App.hasHomeyCompose({ appPath: this.path }) === false) {
+      App.getManifest({ appPath: this.path });
 
-    if( App.hasHomeyCompose({ appPath: this.path }) === false ) {
-      if( await this._askComposeMigration() ) {
+      if (await this._askComposeMigration()) {
         await this.migrateToCompose();
       } else {
         throw new Error("This command requires Homey compose, run `homey app compose` to migrate!");

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1661,82 +1661,9 @@ class App {
       await addArgument();
     }
 
-    const useTokens = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'using_tokens',
-        message: 'Do you want to use tokens for this Flow Card?',
-        default: false
-      }
-    ]);
-
-    let flowTokens = [];
-    if( useTokens.using_tokens ) {
-      async function addToken() {
-        const { tokenTitle, tokenExample } = await inquirer.prompt([
-          {
-            type: 'input',
-            name: 'tokenTitle',
-            message: 'Enter the user title of your token',
-            validate: input => input.length > 0,
-          },
-          {
-            type: 'input',
-            name: 'tokenExample',
-            message: 'Give a brief example of what your token can provide',
-            validate: input => input.length > 0,
-          },
-        ]);
-
-        let tokenAnswers =  await inquirer.prompt([
-          {
-            type: 'list',
-            name: 'type',
-            message: 'What is the type of the token?',
-            choices: [
-              { name: "Text", value: "string" },
-              { name: "Number", value: "number" },
-              { name: "Boolean", value: "boolean" },
-              { name: "Image", value: "image" },
-            ],
-          },
-          {
-            type: 'input',
-            name: 'name',
-            message: 'What the name of your token?',
-            validate: async input => {
-              if( input.search(/^[a-zA-Z0-9-_]+$/) === -1 )
-                throw new Error('Invalid characters: only use [a-zA-Z0-9-_]');
-
-              return true;
-            }
-          }
-        ]);
-
-        const addMore = await inquirer.prompt([
-          {
-            type: 'confirm',
-            name: 'more',
-            message: 'Add more tokens?'
-          }
-        ]);
-
-        flowTokens.push({
-          type: tokenAnswers.type,
-          name: tokenAnswers.name,
-          title: { en: tokenTitle },
-          example : { en: tokenExample },
-        });
-
-        if( addMore.more ) {
-          await addToken();
-        } else {
-          return;
-        }
-      }
-
-      await addToken();
-    }
+    const flowTokens = flowType === 'triggers'
+      ? await App._questionFlowTokens()
+      : [];
 
     const confirm = await inquirer.prompt([
       {
@@ -1762,11 +1689,85 @@ class App {
       flowJson.args = flowArgs;
     }
 
-    if( useTokens.using_tokens ) {
+    if (flowTokens.length) {
       flowJson.tokens = flowTokens;
     }
 
     return flowJson;
+  }
+
+  static async _questionFlowTokens() {
+    const flowTokens = [];
+
+    let { addToken } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'addToken',
+        message: 'Do you want to use tokens for this Flow Card?',
+        default: false
+      }
+    ]);
+
+    while (addToken) {
+      const { tokenTitle, tokenExample } = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'tokenTitle',
+          message: 'Enter the user title of your token',
+          validate: input => input.length > 0,
+        },
+        {
+          type: 'input',
+          name: 'tokenExample',
+          message: 'Give a brief example of what your token can provide',
+          validate: input => input.length > 0,
+        },
+      ]);
+
+      const { tokenType, tokenName } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'tokenType',
+          message: 'What is the type of the token?',
+          choices: [
+            { name: "Text", value: "string" },
+            { name: "Number", value: "number" },
+            { name: "Boolean", value: "boolean" },
+            { name: "Image", value: "image" },
+          ],
+        },
+        {
+          type: 'input',
+          name: 'tokenName',
+          message: 'What the name of your token?',
+          validate: async input => {
+            if( input.search(/^[a-zA-Z0-9-_]+$/) === -1 )
+              throw new Error('Invalid characters: only use [a-zA-Z0-9-_]');
+
+            return true;
+          }
+        }
+      ]);
+
+      flowTokens.push({
+        type: tokenType,
+        name: tokenName,
+        title: { en: tokenTitle },
+        example : { en: tokenExample },
+      });
+
+      const { addAnotherToken } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'addAnotherToken',
+          message: 'Add more tokens?'
+        }
+      ]);
+  
+      addToken = addAnotherToken;
+    }
+
+    return flowTokens;
   }
 
   async createFlow() {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -1584,82 +1584,7 @@ class App {
       }
     ]);
 
-    const useArgs = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'using_arguments',
-        message: 'Do you want to use arguments for this Flow Card?',
-        default: false
-      }
-    ]);
-
-    let flowArgs = [];
-    if ( useArgs.using_arguments ) {
-      // recursive function to add arguments to the flow.
-      async function addArgument() {
-        const { argumentPlaceholder } = await inquirer.prompt([
-          {
-            type: 'input',
-            name: 'argumentPlaceholder',
-            message: 'Enter the placeholder for the argument',
-            validate: input => input.length > 0,
-          }
-        ]);
-
-        let argumentAnswers =  await inquirer.prompt([
-          {
-            type: 'list',
-            name: 'type',
-            message: 'What is the type of the argument?',
-            choices: [
-              { name: "Text", value: "text" },
-              { name: "Number", value: "number" },
-              { name: "Autocomplete", value: "autocomplete" },
-              { name: "Range", value: "range" },
-              { name: "Date", value: "date" },
-              { name: "Time", value: "time" },
-              { name: "Dropdown", value: "dropdown" },
-              { name: "Color", value: "color" },
-              { name: "Droptoken", value: "droptoken" },
-            ],
-          },
-          {
-            type: 'input',
-            name: 'name',
-            message: 'What is the name of your argument?',
-            validate: async input => {
-              if( input.search(/^[a-zA-Z0-9-_]+$/) === -1 )
-                throw new Error('Invalid characters: only use [a-zA-Z0-9-_]');
-
-              return true;
-            }
-          }
-        ]);
-
-        const addMore = await inquirer.prompt([
-          {
-            type: 'confirm',
-            name: 'more',
-            message: 'Add more arguments?'
-          }
-        ]);
-
-        // Create a custom object to inject en flag for the placeholder.
-        flowArgs.push({
-          type: argumentAnswers.type,
-          name: argumentAnswers.name,
-          placeholder: { en: argumentPlaceholder },
-        });
-
-        if( addMore.more ) {
-          await addArgument();
-        } else {
-          return;
-        }
-      }
-
-      await addArgument();
-    }
+    const flowArguments = await App._questionFlowArguments();
 
     const flowTokens = flowType === 'triggers'
       ? await App._questionFlowTokens()
@@ -1685,8 +1610,8 @@ class App {
       flowJson.hint = { en: flowHint };
     }
 
-    if( useArgs.using_arguments ) {
-      flowJson.args = flowArgs;
+    if (flowArguments.length) {
+      flowJson.args = flowArguments;
     }
 
     if (flowTokens.length) {
@@ -1694,6 +1619,79 @@ class App {
     }
 
     return flowJson;
+  }
+
+  static async _questionFlowArguments() {
+    const flowArguments = [];
+
+    let { addArgument } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'addArgument',
+        message: 'Do you want to use arguments for this Flow Card?',
+        default: false
+      }
+    ]);
+
+    while (addArgument) {
+      const { argumentPlaceholder } = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'argumentPlaceholder',
+          message: 'Enter the placeholder for the argument',
+          validate: input => input.length > 0,
+        }
+      ]);
+
+      const { argumentType, argumentName } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'argumentType',
+          message: 'What is the type of the argument?',
+          choices: [
+            { name: "Text", value: "text" },
+            { name: "Number", value: "number" },
+            { name: "Autocomplete", value: "autocomplete" },
+            { name: "Range", value: "range" },
+            { name: "Date", value: "date" },
+            { name: "Time", value: "time" },
+            { name: "Dropdown", value: "dropdown" },
+            { name: "Color", value: "color" },
+            { name: "Droptoken", value: "droptoken" },
+          ],
+        },
+        {
+          type: 'input',
+          name: 'argumentName',
+          message: 'What is the name of your argument?',
+          validate: async input => {
+            if( input.search(/^[a-zA-Z0-9-_]+$/) === -1 )
+              throw new Error('Invalid characters: only use [a-zA-Z0-9-_]');
+
+            return true;
+          }
+        }
+      ]);
+
+      // Create a custom object to inject en flag for the placeholder.
+      flowArguments.push({
+        type: argumentType,
+        name: argumentName,
+        placeholder: { en: argumentPlaceholder },
+      });
+
+      const { addAnotherArgument } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'addAnotherArgument',
+          message: 'Add more arguments?'
+        }
+      ]);
+
+      addArgument = addAnotherArgument;
+    }
+
+    return flowArguments;
   }
 
   static async _questionFlowTokens() {


### PR DESCRIPTION
- [x] do not attempt to validate `/app.json` if homeycompose is enabled
- [x] `homey app flow create` should ask for Flow Card type first
- [x] you can only add Flow Card Tokens if the type is "trigger"
- [x] Flow Card hint should be optional
- [ ] ~What is your Flow card's title? When ...~


Diffs are ugly because of the last two commits where I move some code to new static methods, recommended to review per commit.