### PR TITLE
fix: don't check App.getManifest in preprocess

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -602,7 +602,10 @@ class App {
   }
 
   async preprocess() {
-    App.getManifest({ appPath: this.path });
+    // check if this.path is a homey app folder
+    if (App.hasHomeyCompose({ appPath: this.path }) === false) {
+      App.getManifest({ appPath: this.path });
+    }
 
     Log(colors.green('✓ Pre-processing app...'));
 


### PR DESCRIPTION
Same issue and fix as for discovery and flow.
Not super happy with it as is but since we may be adding additional steps to preprocess (🎉 ) this seemed like the best fix.