### PR TITLE
feat: compose allow filter override to be an object

### DIFF
--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -25,6 +25,7 @@
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
+const url = require('url');
 
 const fse = require('fs-extra');
 const _ = require('underscore');
@@ -42,6 +43,14 @@ const readdirAsync = util.promisify( fs.readdir );
 const deepClone = object => JSON.parse(JSON.stringify(object));
 
 const FLOW_TYPES = [ 'triggers', 'conditions', 'actions' ];
+
+// NOTE: this is supported from Node 12 on but the Homey CLI still supports Node 10
+function objectFromEntries(iterable) {
+  return [...iterable].reduce((obj, [key, val]) => {
+    obj[key] = val
+    return obj
+  }, {});
+}
 
 class HomeyCompose {
 
@@ -310,13 +319,18 @@ class HomeyCompose {
               });
             }
 
-            const filter = card.$filter || '';
+            const additionalFilters = typeof card.$filter === 'string'
+              ? objectFromEntries(new url.URLSearchParams(card.$filter).entries())
+              : card.$filter;
 
             card.args = card.args || [];
             card.args.unshift({
               type: 'device',
               name: card.$deviceName || 'device',
-              filter: `driver_id=${driverId}` + (filter ? `&${filter}` : ''),
+              filter: {
+                ...additionalFilters,
+                driverId,
+              }
             })
 
             await this._addFlowCard({

--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -330,6 +330,8 @@ class HomeyCompose {
               filter: {
                 ...additionalFilters,
                 driverId,
+                // we need to prevent users from specifying `driver_id` as well.
+                'driver_id': undefined,
               }
             })
 


### PR DESCRIPTION
This makes the behaviour of `$filter` "Driver Flow Compose" option more similar to the `filter` option of "Flow card device arguments". This way the documentation be simpler because I can choose to only explain the object syntax plus the `|` and `,` characters.

Alternatively I update the documentation to only explain the URL search params syntax for `filter` and we keep not supporting the object style.