### PR TITLE
Revert "feat: compose allow filter override to be an object"

### DIFF
--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -25,7 +25,6 @@
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
-const url = require('url');
 
 const fse = require('fs-extra');
 const _ = require('underscore');
@@ -43,14 +42,6 @@ const readdirAsync = util.promisify( fs.readdir );
 const deepClone = object => JSON.parse(JSON.stringify(object));
 
 const FLOW_TYPES = [ 'triggers', 'conditions', 'actions' ];
-
-// NOTE: this is supported from Node 12 on but the Homey CLI still supports Node 10
-function objectFromEntries(iterable) {
-  return [...iterable].reduce((obj, [key, val]) => {
-    obj[key] = val
-    return obj
-  }, {});
-}
 
 class HomeyCompose {
 
@@ -319,20 +310,13 @@ class HomeyCompose {
               });
             }
 
-            const additionalFilters = typeof card.$filter === 'string'
-              ? objectFromEntries(new url.URLSearchParams(card.$filter).entries())
-              : card.$filter;
+            const filter = card.$filter || '';
 
             card.args = card.args || [];
             card.args.unshift({
               type: 'device',
               name: card.$deviceName || 'device',
-              filter: {
-                ...additionalFilters,
-                driverId,
-                // we need to prevent users from specifying `driver_id` as well.
-                'driver_id': undefined,
-              }
+              filter: `driver_id=${driverId}` + (filter ? `&${filter}` : ''),
             })
 
             await this._addFlowCard({


### PR DESCRIPTION
Reverts athombv/node-homey#161

This breaks `titleFormatted` validation because it always tries to parse the filter as a querystring to figure out which arguments are device arguments. https://github.com/athombv/node-homey-lib/pull/275

I'm not 100% confident but I think the "missing argument" validation is also ran on Homey this is a backwards incompatible change. If we want to still support the "object-style" for `$filter` we can go from object to string instead of string to object.