### PR TITLE
fix: version app json

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -2273,7 +2273,20 @@ class App {
   }
 
   static hasHomeyCompose({ appPath }) {
-    return fs.existsSync(path.join(appPath, '.homeycompose'));
+    const hasComposeFolder = fs.existsSync(path.join(appPath, '.homeycompose'));
+
+    if (
+      hasComposeFolder &&
+      !this.__warnedAboutMissingHomeyComposeManifest &&
+      !fs.existsSync(path.join(appPath, '.homeycompose/app.json'))
+    ) {
+      Log(colors.yellow('⚠ Warning: Could not find a Homey Compose app.json manifest!'));
+      Log(colors.yellow('Using the generated app.json in the root of your app is supported for now,'));
+      Log(colors.yellow('but it is recommended to move your manifest to the .homeycompose/ folder.'));
+      this.__warnedAboutMissingHomeyComposeManifest = true;
+    }
+
+    return hasComposeFolder;
   }
 
   static getManifest({ appPath }) {

--- a/lib/App.js
+++ b/lib/App.js
@@ -644,14 +644,24 @@ class App {
   }
 
   async version(version) {
-    // HACK: we want to get the "source" manifest, which means if Homey Compose is enabled
-    // we want to read from and write to the .homeycompose/app.json file.
-    // We trick `getManifest` to look into the wrong folder to read and validate the manifest.
-    const manifestFolder = App.hasHomeyCompose({ appPath: this.path })
-      ? path.join(this.path, '.homeycompose')
-      : this.path;
+    let manifest;
+    let manifestFolder;
 
-    const manifest = App.getManifest({ appPath: manifestFolder });
+    if (App.hasHomeyCompose({ appPath: this.path })) {
+      try {
+        // HACK: We trick `getManifest` to look into the wrong folder to read and validate the manifest.
+        const composePath = path.join(this.path, '.homeycompose');
+        manifest = App.getManifest({ appPath: composePath });
+        manifestFolder = composePath;
+      } catch (error) {
+        // .homeycompose/app.json is optional, you can use a root regular app.json
+      }
+    }
+
+    if (!manifest) {
+      manifest = App.getManifest({ appPath: this.path });
+      manifestFolder = this.path;
+    }
 
     switch (true) {
       case semver.valid(version):


### PR DESCRIPTION
Fixes: https://github.com/athombv/homey-apps-sdk-issues/issues/198

Makes `.homeycompose/app.json` optional in the `homey app version` command (which is also part of `homey app publish`). We fallback to the "regular" `app.json` if it doesn't exist.

I also added a warning when `.homeycompose/app.json` is missing, I'm not sure we should warn but I thought I'd suggest it.
