### PR TITLE
feat: update npm-version-bump-and-publish.yml

### DIFF
--- a/.github/workflows/npm-version-bump-and-publish.yml
+++ b/.github/workflows/npm-version-bump-and-publish.yml
@@ -21,9 +21,14 @@ name: NPM
 #   branch. If pushing to a non-protected branch replace HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN with GITHUB_TOKEN
 
 # Optional secrets:
-# - SSH_KEY: required if `npm ci` needs to install private npm packages, make sure to enable webfactory/ssh-agent@v0.2.0 step
+# - SSH_KEY: required if `npm ci` needs to install private npm packages
 
 # Note: make sure to commit package-lock.json, this is needed for `npm ci`.
+
+# Note: add `.github` to .npmignore
+
+# Note: when publishing a scoped npm package (e.g. @athombv/node-my-package) append `--access public` to the `npm publish` command, by default scoped packages are published privately.
+# For more information see: https://docs.npmjs.com/creating-and-publishing-an-org-scoped-package
 
 # Defines the trigger for this action, in general you want it to run when pushing to production | testing. For more
 # information see: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events)
@@ -32,6 +37,11 @@ on:
     branches:
       - production
       - testing
+  workflow_dispatch:
+    inputs:
+      versionBumpType:
+        description: 'Version bump type (major, minor or patch)'
+        required: true
 
 jobs:
   npm_version_bump_and_publish:
@@ -64,48 +74,51 @@ jobs:
           # Needed for publishing to npm
           registry-url: 'https://registry.npmjs.org'
 
-      # Only use the ssh-agent action below if your repository has private git dependencies (see README.md for
-      # instructions on how to configure an ssh key).
-      # - uses: webfactory/ssh-agent@v0.2.0
-      #  with:
-      #    ssh-private-key: ${{ secrets.SSH_KEY }}
+      # Set SSH key
+      - uses: webfactory/ssh-agent@v0.4.1
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        if: env.SSH_KEY != null
+        with:
+          ssh-private-key: ${{ env.SSH_KEY }}
 
       # Run `npm ci` to re-create your local environment (make sure to commit your package-lock.json!).
       - name: Build
         run: npm ci
 
       - name: Version bump patch
-        if: "contains(github.event.head_commit.message, '#patch') && !contains(github.event.head_commit.message, '#minor') && !contains(github.event.head_commit.message, '#major')"
+        if: github.event.inputs.versionBumpType == 'patch' || "contains(github.event.head_commit.message, '#patch') && !contains(github.event.head_commit.message, '#minor') && !contains(github.event.head_commit.message, '#major')"
         run: |
           npm version patch
           git pull
           git push --follow-tags
 
       - name: Version bump minor
-        if: "contains(github.event.head_commit.message, '#minor') && !contains(github.event.head_commit.message, '#major')"
+        if: github.event.inputs.versionBumpType == 'minor' || "contains(github.event.head_commit.message, '#minor') && !contains(github.event.head_commit.message, '#major')"
         run: |
           npm version minor
           git pull
           git push --follow-tags
 
       - name: Version bump major
-        if: "contains(github.event.head_commit.message, '#major')"
+        if: github.event.inputs.versionBumpType == 'major' || "contains(github.event.head_commit.message, '#major')"
         run: |
           npm version major
           git pull
           git push --follow-tags
 
-      # Publish when this action is running on branch production
+      # Publish when this action is running on branch production (when publishing a scoped package add --access public)
       - name: Publish
         if: github.ref == 'refs/heads/production'
         run: |
           npm publish
           VERSION="$(node -p "require('./package.json').version")"
           echo package_version=${VERSION} >> $GITHUB_ENV
+          echo $package_version
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
-      # Publish to beta when this action is running on branch testing
+      # Publish to beta when this action is running on branch testing (when publishing a scoped package add --access public)
       - name: Publish to beta
         if: github.ref == 'refs/heads/testing'
         run: |
@@ -114,3 +127,15 @@ jobs:
           echo package_version=${VERSION} >> $GITHUB_ENV
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+
+      # Post a Slack notification in #software on success/failure
+      - name: Slack notify
+        if: always()
+        uses: innocarpe/actions-slack@v1
+        with:
+          status: ${{ job.status }}
+          success_text: '${{github.repository}} - published v${{env.package_version}} to npm 🚀'
+          failure_text: '${{github.repository}} - failed to publish to npm'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Required
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Required


### PR DESCRIPTION
Add manual trigger functionality.

@tjallingt lets test this with the next node-homey release ok? I think it should work as is, but that worflow syntax is confusing sometimes. 