### PR TITLE
fix: support filter object

### DIFF
--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -25,6 +25,7 @@
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
+const url = require('url');
 
 const fse = require('fs-extra');
 const _ = require('underscore');
@@ -310,7 +311,12 @@ class HomeyCompose {
               });
             }
 
-            const filter = card.$filter || '';
+            let filter = '';
+            if (typeof card.$filter === 'string') {
+              filter = card.$filter;
+            } else if (typeof card.$filter === 'object') {
+              filter = new url.URLSearchParams(card.$filter).toString();
+            }
 
             card.args = card.args || [];
             card.args.unshift({


### PR DESCRIPTION
This fixes the issue that https://github.com/athombv/node-homey/pull/161 attempted to fix.

Filters can be objects with arrays, these are all correctly encoded by `url.URLSearchParams()`. Homey uses `querystring.parse` to read the values from the filter which works with the output of the `URLSearchParams`.