### PR TITLE
fix: ensure Flow number argument options are numbers

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -1932,9 +1932,9 @@ class App {
           },
         ]);
 
-        flowCardArgument.min = argumentMin;
-        flowCardArgument.max = argumentMax;
-        flowCardArgument.step = argumentStep;
+        flowCardArgument.min = Number(argumentMin);
+        flowCardArgument.max = Number(argumentMax);
+        flowCardArgument.step = Number(argumentStep);
       }
 
       if (flowCardArgument.type === 'dropdown') {


### PR DESCRIPTION
Ensures the generated Flow passes validation.
Tried to update the inquirer version to one that supports `"type": "number"` but ran into issues with the default values.