### PR TITLE
fix: check object is not null

### DIFF
--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -244,7 +244,11 @@ class HomeyCompose {
         if (err.code !== 'ENOENT') throw new Error(err);
       }
 
-      if (typeof driverJson.$flow === 'object' && !Array.isArray(driverJson.$flow)) {
+      if (
+        typeof driverJson.$flow === 'object'
+        && driverJson.$flow !== null
+        && !Array.isArray(driverJson.$flow)
+      ) {
         for (let i = 0; i < FLOW_TYPES.length; i++) {
           const type = FLOW_TYPES[i];
           const cards = driverJson.$flow[type];
@@ -279,7 +283,7 @@ class HomeyCompose {
             let filter = '';
             if (typeof card.$filter === 'string') {
               filter = card.$filter;
-            } else if (typeof card.$filter === 'object') {
+            } else if (typeof card.$filter === 'object' && card.$filter !== null) {
               filter = new url.URLSearchParams(card.$filter).toString();
             }
 
@@ -309,18 +313,15 @@ class HomeyCompose {
   }
 
   replaceSpecialPropertiesRecursive(obj, driverId, driverJson) {
-    let zwaveParameterIndex;
     if (typeof obj !== 'object' || obj === null) return obj;
 
     // store last found zwave parameter index
+    let zwaveParameterIndex;
     if (Object.prototype.hasOwnProperty.call(obj, 'zwave') && Object.prototype.hasOwnProperty.call(obj.zwave, 'index')) {
       zwaveParameterIndex = obj.zwave.index;
     }
 
     for (const key of Object.keys(obj)) {
-      if (typeof obj[key] === 'object') {
-        obj[key] = this.replaceSpecialPropertiesRecursive(obj[key], driverId, driverJson);
-      }
       if (typeof obj[key] === 'string') {
         obj[key] = obj[key].replace(/{{driverId}}/g, driverId);
 
@@ -340,6 +341,8 @@ class HomeyCompose {
         if (zwaveParameterIndex) {
           obj[key] = obj[key].replace(/{{zwaveParameterIndex}}/g, zwaveParameterIndex);
         }
+      } else {
+        obj[key] = this.replaceSpecialPropertiesRecursive(obj[key], driverId, driverJson);
       }
     }
     return obj;
@@ -496,7 +499,7 @@ class HomeyCompose {
 
   async _saveAppJson() {
     function removeDollarPropertiesRecursive(obj) {
-      if (typeof obj !== 'object') return obj;
+      if (typeof obj !== 'object' || obj === null) return obj;
       for (const key of Object.keys(obj)) {
         if (key.indexOf('$') === 0) {
           delete obj[key];


### PR DESCRIPTION
Fixes: https://github.com/athombv/homey-apps-sdk-issues/issues/216

Small regression from the eslint fix changes. Updated the code to check `value !== null` in addition to `typeof value === 'object'` everywhere.