### PR TITLE
fix: check correct property of templateCards

### DIFF
--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -266,7 +266,7 @@ class HomeyCompose {
               let templateId;
               for (const k of Object.keys(templateIds)) {
                 templateId = templateIds[k];
-                if (!templateCards.templateId) {
+                if (!templateCards[templateId]) {
                   throw new Error(`Invalid driver flow template for driver ${driverId}: ${templateId}`);
                 }
                 flowTemplate = Object.assign(flowTemplate, templateCards[templateId]);

--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -263,9 +263,7 @@ class HomeyCompose {
               const templateCards = flowTemplates[type];
 
               let flowTemplate = {};
-              let templateId;
-              for (const k of Object.keys(templateIds)) {
-                templateId = templateIds[k];
+              for (const templateId of templateIds) {
                 if (!templateCards[templateId]) {
                   throw new Error(`Invalid driver flow template for driver ${driverId}: ${templateId}`);
                 }
@@ -274,7 +272,7 @@ class HomeyCompose {
 
               // assign template to original flow object
               Object.assign(card, {
-                id: card.$id || templateId,
+                id: card.$id || templateIds[templateIds.length - 1],
                 ...flowTemplate,
                 ...card,
               });


### PR DESCRIPTION
Fixes https://github.com/athombv/homey-apps-sdk-issues/issues/218

The check used to be

https://github.com/athombv/node-homey/blob/e76927e2d649201441ab16e7a87deeacdac6f0f1/lib/HomeyCompose.js#L300

But now we check

```js
if (!templateCards.templateId)
```