### PR TITLE
fix: copy to build folder and use for Homey Cloud

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -661,8 +661,10 @@ class App {
     await fse.remove(path.join(this.path, 'build'));
 
     // Copy app source over to build/
-    const files = await this._getAppSourceFiles();
-    await Promise.all(files.map(filePath => {
+    const sourceFiles = await this._getAppSourceFiles();
+    const dependencies = await NpmCommands.getProductionDependencies({ appPath: this.path });
+
+    await Promise.all(sourceFiles.concat(dependencies).map(filePath => {
       return fse.copy(path.join(this.path, filePath), path.join(this.path, 'build', filePath));
     }));
 
@@ -1089,8 +1091,6 @@ class App {
       follow: true,
     });
 
-    const prunePaths = await NpmCommands.getPrunePaths({ path: this.path });
-
     const ignoreRules = [
       '.*',
       '*.ts',
@@ -1098,14 +1098,15 @@ class App {
       'env.json',
       '*.compose.json',
       'build/*',
-      ...prunePaths,
+      'node_modules/*',
     ];
-    // Add a "file" containing our default ignore rules for dotfiles, env.json and npm prune paths
+    // Add a "file" containing our default ignore rules for dotfiles, env.json and node_modules
     walker.onReadIgnoreFile(DEFAULT_IGNORE_RULES_FILE, ignoreRules.join('\r\n'), () => {});
 
     const fileEntries = await new Promise((resolve, reject) => {
       walker.on('done', resolve).on('error', reject).start();
     });
+
     return fileEntries;
   }
 

--- a/lib/App.js
+++ b/lib/App.js
@@ -717,23 +717,6 @@ class App {
   async publish() {
     await this.preprocess();
 
-    if (await fse.pathExists(path.join(this.path, 'package.json'))) {
-      const hasAllModules = await NpmCommands.listModules({ path: this.path });
-      if (!hasAllModules) {
-        const continueOnError = await inquirer.prompt([
-          {
-            type: 'confirm',
-            name: 'value',
-            default: false,
-            message: 'Not all node modules are installed. Are you sure you want to continue?',
-          },
-        ]);
-        if (!continueOnError.value) {
-          throw new Error('✖ Please run "npm install" to install any missing node modules.');
-        }
-      }
-    }
-
     const profile = await AthomApi.getProfile();
     const level = profile.roleIds.includes('app_developer_trusted')
       ? 'verified'

--- a/lib/App.js
+++ b/lib/App.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const zlib = require('zlib');
 const http = require('http');
+const stream = require('stream');
 const { promisify } = require('util');
 
 const { AthomAppsAPI } = require('athom-api');
@@ -46,6 +47,8 @@ const readFileAsync = promisify(fs.readFile);
 const writeFileAsync = promisify(fs.writeFile);
 const copyFileAsync = promisify(fs.copyFile);
 const readDirAsync = promisify(fs.readdir);
+
+const pipeline = promisify(stream.pipeline);
 
 const INVALID_CHARACTERS = /[^a-zA-Z0-9-_]/g;
 const FLOW_TYPES = ['triggers', 'conditions', 'actions'];
@@ -1037,31 +1040,28 @@ class App {
   }
 
   async _getPackStream() {
-    return tmp.file().then(async o => {
-      const tmpPath = o.path;
+    let appSize = 0;
+    const tmpFile = await tmp.file();
 
-      return new Promise((resolve, reject) => {
-        let appSize = 0;
-        const writeFileStream = fs.createWriteStream(tmpPath)
-          .once('close', () => {
-            Log(colors.grey(` — App size: ${filesize(appSize)}`));
-            const readFileStream = fs.createReadStream(tmpPath);
-            readFileStream.once('close', () => {
-              o.cleanup();
-            });
-            resolve(readFileStream);
-          })
-          .once('error', reject);
+    await pipeline(
+      tar.pack(path.join(this.path, 'build'), { dereference: true }).on('data', chunk => {
+        appSize += chunk.length;
+      }),
+      zlib.createGzip(),
+      fs.createWriteStream(tmpFile.path),
+    );
 
-        tar
-          .pack(path.join(this.path, 'build'), { dereference: true })
-          .on('data', chunk => {
-            appSize += chunk.length;
-          })
-          .pipe(zlib.createGzip())
-          .pipe(writeFileStream);
+    Log(colors.grey(` — App size: ${filesize(appSize)}`));
+
+    const readFileStream = fs.createReadStream(tmpFile.path);
+
+    stream.finished(readFileStream, () => {
+      tmpFile.cleanup().catch(error => {
+        // ignore
       });
     });
+
+    return readFileStream;
   }
 
   async _getAppSourceFiles() {

--- a/lib/App.js
+++ b/lib/App.js
@@ -1519,7 +1519,7 @@ class App {
         ]);
 
         if (shouldInstallRFDriver) {
-          await NpmCommands.install({ save: true, path: this.path }, { id: 'homey-rfdriver' });
+          await NpmCommands.install(['homey-rfdriver'], { appPath: this.path });
         }
         break;
       }
@@ -1534,7 +1534,7 @@ class App {
         ]);
 
         if (shouldInstallRFDriver) {
-          await NpmCommands.install({ save: true, path: this.path }, { id: 'homey-rfdriver' });
+          await NpmCommands.install(['homey-rfdriver'], { appPath: this.path });
         }
         break;
       }
@@ -1549,7 +1549,7 @@ class App {
         ]);
 
         if (shouldInstallZigbeeDriver) {
-          await NpmCommands.install({ save: true, path: this.path }, { id: 'homey-zigbeedriver' });
+          await NpmCommands.install(['homey-zigbeedriver'], { appPath: this.path });
         }
         break;
       }
@@ -1564,7 +1564,7 @@ class App {
         ]);
 
         if (shouldInstallZwaveDriver) {
-          await NpmCommands.install({ save: true, path: this.path }, { id: 'homey-zwavedriver' });
+          await NpmCommands.install(['homey-zwavedriver'], { appPath: this.path });
         }
 
         await ZWave.autocompleteDriver({ driverPath, driverJson });
@@ -1581,7 +1581,7 @@ class App {
         ]);
 
         if (shouldInstallOAuth2App) {
-          await NpmCommands.install({ save: true, path: this.path }, { id: 'homey-oauth2app' });
+          await NpmCommands.install(['homey-oauth2app'], { appPath: this.path });
         }
         break;
       }
@@ -2495,43 +2495,24 @@ class App {
   }
 
   static async addTypes({ appPath }) {
-    // Check if npm is available, then install homey type declarations as dev dependency
-    const npmInstalled = await NpmCommands.isNpmInstalled();
-    if (npmInstalled) {
-      let devDependencies = [{
-        id: '@types/homey@npm:homey-apps-sdk-v3-types',
-      }];
-      if (App.usesTypeScript({ appPath })) {
-        const tsDependencies = [{
-          id: 'typescript',
-        },
-        {
-          id: '@types/node',
-        },
-        {
-          id: '@types/source-map-support',
-        },
-        {
-          id: '@tsconfig/node12',
-        }];
-        devDependencies = [...devDependencies, ...tsDependencies];
+    // eslint-disable-next-line prefer-const
+    let devDependencies = ['@types/homey@npm:homey-apps-sdk-v3-types'];
 
-        await NpmCommands.install({ save: true, path: appPath }, {
-          id: 'source-map-support',
-        });
-      }
-      if (App.usesESLint({ appPath })) {
-        const eslintDependencies = [{
-          id: 'eslint',
-        },
-        {
-          id: 'eslint-config-athom',
-        }];
-        devDependencies = [...devDependencies, ...eslintDependencies];
-      }
+    if (App.usesTypeScript({ appPath })) {
+      devDependencies.push('typescript');
+      devDependencies.push('@types/node');
+      devDependencies.push('@types/source-map-support');
+      devDependencies.push('@tsconfig/node12');
 
-      await NpmCommands.install({ saveDev: true, path: appPath }, devDependencies);
+      await NpmCommands.install(['source-map-support'], { appPath });
     }
+
+    if (App.usesESLint({ appPath })) {
+      devDependencies.push('eslint');
+      devDependencies.push('eslint-config-athom');
+    }
+
+    await NpmCommands.installDev(devDependencies, { appPath });
   }
 
   static hasHomeyCompose({ appPath }) {

--- a/lib/App.js
+++ b/lib/App.js
@@ -68,17 +68,13 @@ class App {
     return fs.existsSync(path.join(appPath, '.eslintrc.json'));
   }
 
-  async transpileToTypescript(appPath) {
+  static async transpileToTypescript({ appPath }) {
     Log(colors.green('✓ Typescript detected. Compiling...'));
 
     try {
-      const newPath = path.join(appPath, 'build/');
-      await fse.remove(newPath).catch(err => {});
       await exec('npm run build', { cwd: appPath });
 
-      appPath = newPath;
       Log(colors.green('✓ Typescript compilation successful'));
-      return appPath;
     } catch (err) {
       Log(colors.red('✖ Error occurred during while running tsc'));
       Log(err.stdout);
@@ -584,7 +580,7 @@ class App {
           ...(HOMEY_APP_RUNNER_SDK_PATH
             ? [`${HOMEY_APP_RUNNER_SDK_PATH}:/homey-app-runner/node_modules/homey-apps-sdk-v3:ro`]
             : []),
-          `${this.path}:/app:ro`,
+          `${path.join(this.path, 'build')}:/app:ro`,
         ],
       },
     };
@@ -654,14 +650,25 @@ class App {
       App.getManifest({ appPath: this.path });
     }
 
-    if (App.usesTypeScript({ appPath: this.path })) {
-      await this.transpileToTypescript(this.path);
-    }
-
     Log(colors.green('✓ Pre-processing app...'));
 
+    // Build app.json from Homey Compose files
     if (App.hasHomeyCompose({ appPath: this.path })) {
       await HomeyCompose.build({ appPath: this.path });
+    }
+
+    // Clear the build/ folder
+    await fse.remove(path.join(this.path, 'build'));
+
+    // Copy app source over to build/
+    const files = await this._getAppSourceFiles();
+    await Promise.all(files.map(filePath => {
+      return fse.copy(path.join(this.path, filePath), path.join(this.path, 'build', filePath));
+    }));
+
+    // Compile TypeScript files to build/
+    if (App.usesTypeScript({ appPath: this.path })) {
+      await App.transpileToTypescript({ appPath: this.path });
     }
   }
 
@@ -1044,44 +1051,9 @@ class App {
     }
   }
 
-  /**
-   * Method performs a npm prune dry run. It reads the generated JSON
-   * and based on that builds an array of paths that need
-   * to be ignored during the tar process. If anything goes wrong,
-   * an empty array is returned (hence no paths will be pruned).
-   * @returns {Promise<String[]>}
-   * @private
-   */
-  async _getPrunePaths() {
-    // Check if npm is available then start prune dry-run
-    const npmInstalled = await NpmCommands.isNpmInstalled();
-    if (npmInstalled) {
-      Log(colors.green('✓ Pruning dev dependencies...'));
-      return NpmCommands.getPrunePaths({ path: this.path });
-    }
-    return [];
-  }
-
   async _getPackStream() {
     return tmp.file().then(async o => {
       const tmpPath = o.path;
-
-      // Get list of files to pack, excluding npm prune paths and files in .homeyignore
-      const prunePaths = await this._getPrunePaths();
-      const fileEntries = await this._getPackFileEntries(prunePaths);
-
-      const tarOpts = {
-        entries: fileEntries,
-        dereference: true,
-
-        // Move every file in build to the main directory of the tar
-        map(header) {
-          if (header.name.startsWith('build/')) {
-            header.name = header.name.replace('build/', '');
-          }
-          return header;
-        },
-      };
 
       return new Promise((resolve, reject) => {
         let appSize = 0;
@@ -1097,7 +1069,7 @@ class App {
           .once('error', reject);
 
         tar
-          .pack(this.path, tarOpts)
+          .pack(path.join(this.path, 'build'), { dereference: true })
           .on('data', chunk => {
             appSize += chunk.length;
           })
@@ -1107,17 +1079,29 @@ class App {
     });
   }
 
-  async _getPackFileEntries(prunePaths) {
+  async _getAppSourceFiles() {
+    const DEFAULT_IGNORE_RULES_FILE = '$default-ignore-rules';
+
     const walker = new ignoreWalk.Walker({
       path: this.path,
-      ignoreFiles: ['.homeyignore', ''], // Empty string is workaround for adding default ignore rules
+      ignoreFiles: ['.homeyignore', DEFAULT_IGNORE_RULES_FILE],
       includeEmpty: true,
       follow: true,
     });
 
-    // Add default ignore rules for dotfiles, env.json and npm prune paths
-    const ignoreRules = ['.*', '*.ts', 'tsconfig.json', 'env.json', ...prunePaths];
-    walker.onReadIgnoreFile('', ignoreRules.join('\r\n'), () => {});
+    const prunePaths = await NpmCommands.getPrunePaths({ path: this.path });
+
+    const ignoreRules = [
+      '.*',
+      '*.ts',
+      'tsconfig.json',
+      'env.json',
+      '*.compose.json',
+      'build/*',
+      ...prunePaths,
+    ];
+    // Add a "file" containing our default ignore rules for dotfiles, env.json and npm prune paths
+    walker.onReadIgnoreFile(DEFAULT_IGNORE_RULES_FILE, ignoreRules.join('\r\n'), () => {});
 
     const fileEntries = await new Promise((resolve, reject) => {
       walker.on('done', resolve).on('error', reject).start();

--- a/lib/NpmCommands.js
+++ b/lib/NpmCommands.js
@@ -118,21 +118,6 @@ class NpmCommands {
       .filter(filePath => filePath !== '');
   }
 
-  static async listModules({ path }) {
-    const npmInstalled = await NpmCommands.isNpmInstalled();
-    if (!npmInstalled) {
-      Log(colors.red('✖ Could not execute npm list, please install npm globally'));
-      return false; // Return false to be safe
-    }
-
-    try {
-      await exec('npm list', { cwd: path });
-      return true;
-    } catch (err) {
-      return false;
-    }
-  }
-
 }
 
 module.exports = NpmCommands;

--- a/lib/NpmCommands.js
+++ b/lib/NpmCommands.js
@@ -1,12 +1,10 @@
 'use strict';
 
+const path = require('path');
 const util = require('util');
-const _path = require('path');
 const childProcess = require('child_process');
 
-const fse = require('fs-extra');
 const colors = require('colors');
-const npm = require('npm-programmatic');
 
 const { Log } = require('..');
 
@@ -15,95 +13,35 @@ const exec = util.promisify(childProcess.exec);
 class NpmCommands {
 
   /**
-   * Check if npm is installed. By using --version git will not exit with an error code
+   * Execute npm install for a given packageId or array of packageIds.
+   * @param {string[]} packages - List of packages that should be installed (e.g. ['request'] or ['request@1.2.3'])
+   * @param {{ appPath?: string }} [options] - Current working directory where npm install should be executed.
+   * @returns {Promise<void>}
    */
-  static async isNpmInstalled() {
-    try {
-      const { stdout } = await exec('npm --version');
-
-      return !!stdout;
-    } catch (error) {
-      return false;
-    }
-  }
-
-  /**
-   * Get the version of a currently listed package.
-   * @param {string} packageName
-   * @param {string} appPath
-   * @returns {Promise<string|null>} - Semver version (e.g. 1.0.0)
-   */
-  static async getPackageVersion({ packageName, appPath }) {
-    try {
-      const requirePath = _path.join(appPath, 'node_modules', packageName, 'package.json');
-      // eslint-disable-next-line
-      return require(requirePath).version;
-    } catch (error) {
-      return null; // package probably not installed
-    }
+  static async install(packages, { appPath } = {}) {
+    Log(colors.green(`✓ Installing dependencies: ${packages.join(', ')}`));
+    await exec(`npm install --save ${packages.join(' ')}`, { cwd: appPath });
+    Log(colors.green('✓ Installation complete'));
   }
 
   /**
    * Execute npm install for a given packageId or array of packageIds.
-   * @param {boolean} [save=true] - npm --save flag
-   * @param {boolean} [saveDev=false] - npm --save-dev flag
-   * @param {string} [path=process.cwd()] - Current working directory
-   * where npm install should be executed.
-   * @param {string|Array<String>|Array<Object<{id:String, version:String}>>} packageIds -
-   *  Package (or packages if Array) that should be installed (e.g. 'request' or 'request@1.2.3'.
+   * @param {string[]} packages - List of packages that should be installed (e.g. ['request'] or ['request@1.2.3'])
+   * @param {{ appPath?: string }} [options] - Current working directory where npm install should be executed.
    * @returns {Promise<void>}
    */
-  static async install({ save = true, saveDev = false, path = process.cwd() }, packageIds) {
-    if (!(packageIds instanceof Array)) packageIds = [packageIds]; // Wrap in array if needed
-    if (typeof path !== 'string') throw new TypeError('expected_path_string');
-
-    // Convert Array of objects to strings
-    packageIds = packageIds.map(packageId => {
-      if (typeof packageId === 'string') {
-        return packageId;
-      }
-      if (Object.prototype.hasOwnProperty.call(packageId, 'id')
-        && typeof packageId.id === 'string'
-        && Object.prototype.hasOwnProperty.call(packageId, 'version')
-        && typeof packageId.version === 'string') {
-        return `${packageId.id}@${packageId.version}`;
-      }
-      if (Object.prototype.hasOwnProperty.call(packageId, 'id')
-        && typeof packageId.id === 'string') {
-        return `${packageId.id}`;
-      }
-      throw new Error('invalid packageId');
-    });
-
-    // Build log string based on provided packageIds
-    let packageIdLogStrings = '';
-    packageIds.forEach((packageId, i) => {
-      packageIdLogStrings += `${i >= 1 ? ', ' : ''}${packageId}`;
-    });
-    const logString = `✓ Installing ${saveDev ? 'npm dev' : 'npm'} package${packageIds.length > 1 ? 's' : ''} (${packageIdLogStrings})`;
-    Log(colors.green(logString));
-
-    // Install packageIds
-    await fse.ensureDir(_path.join(path, 'node_modules'));
-
-    // Specify install options
-    const installOpts = { cwd: path };
-
-    // Add saveDev or save flag
-    if (saveDev) installOpts.saveDev = true;
-    else if (save) installOpts.save = true;
-
-    // Install
-    await npm.install(packageIds, installOpts);
+  static async installDev(packages, { appPath } = {}) {
+    Log(colors.green(`✓ Installing dev dependencies: ${packages.join(', ')}`));
+    await exec(`npm install --save-dev ${packages.join(' ')}`, { cwd: appPath });
     Log(colors.green('✓ Installation complete'));
   }
 
   /**
    * Execute npm ls to get a list of production dependencies.
-   * @param {string} path
+   * @param {{ appPath?: string }} [options]
    * @returns {Promise<string[]>}
    */
-  static async getProductionDependencies({ appPath }) {
+  static async getProductionDependencies({ appPath } = {}) {
     // node-homey has installed npm 6 as a dependency so we can resolve it
     const nodeHomeyNPMPath = require.resolve('npm');
 
@@ -114,7 +52,7 @@ class NpmCommands {
 
     return stdout
       .split('\n')
-      .map(filePath => _path.relative(appPath, filePath))
+      .map(filePath => path.relative(appPath, filePath))
       .filter(filePath => filePath !== '');
   }
 

--- a/lib/NpmCommands.js
+++ b/lib/NpmCommands.js
@@ -4,7 +4,6 @@ const util = require('util');
 const _path = require('path');
 const childProcess = require('child_process');
 
-const upath = require('upath');
 const fse = require('fs-extra');
 const colors = require('colors');
 const npm = require('npm-programmatic');
@@ -100,34 +99,23 @@ class NpmCommands {
   }
 
   /**
-   * Execute npm prune and parse the JSON response.
-   * Pick the required properties and return an array of paths to be pruned.
+   * Execute npm ls to get a list of production dependencies.
    * @param {string} path
    * @returns {Promise<string[]>}
    */
-  static async getPrunePaths({ path }) {
-    const npmInstalled = await NpmCommands.isNpmInstalled();
-
-    if (!npmInstalled) {
-      Log(colors.red('✖ Could not execute npm prune, please install npm globally'));
-      return []; // Return empty array to be safe
-    }
-
+  static async getProductionDependencies({ appPath }) {
     // node-homey has installed npm 6 as a dependency so we can resolve it
     const nodeHomeyNPMPath = require.resolve('npm');
 
-    try {
-      // Perform prune dry run and parse the JSON response
-      const { stdout } = await exec(`node ${nodeHomeyNPMPath} prune --production --dry-run --json`, { cwd: path });
-      const prunePathsJson = JSON.parse(stdout);
-      const prunePaths = prunePathsJson.removed.map(pruneObject => {
-        return upath.normalize(pruneObject.path) + upath.sep;
-      });
-      return prunePaths;
-    } catch (err) {
-      Log(colors.red('✖ Error occurred during npm prune', err));
-      return [];
-    }
+    // Note: if we ever upgrade to npm@7 this command will also list packages that are on disk
+    // but no longer in the package.json or package-lock.json. We can add the --package-lock-only
+    // flag to prevent this but then it will throw when there is no lock file.
+    const { stdout } = await exec(`node ${nodeHomeyNPMPath} ls --parseable --all --only=prod`, { cwd: appPath });
+
+    return stdout
+      .split('\n')
+      .map(filePath => _path.relative(appPath, filePath))
+      .filter(filePath => filePath !== '');
   }
 
   static async listModules({ path }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,11 +434,6 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -5620,14 +5615,6 @@
             }
           }
         }
-      }
-    },
-    "npm-programmatic": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/npm-programmatic/-/npm-programmatic-0.0.12.tgz",
-      "integrity": "sha512-fvZdiJS038ZH31z59cEiIywOcgX1u23aLc0wAKF4btyhbYQxE93wTQjzs/URERK+GhS/QghDILQmEvgxu77/zQ==",
-      "requires": {
-        "bluebird": "^3.4.1"
       }
     },
     "object-assign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6675,11 +6675,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "upath": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w=="
-    },
     "update-notifier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "monitorctrlc": "^2.0.1",
     "node-fetch": "^2.1.1",
     "npm": "^6.14.11",
-    "npm-programmatic": "0.0.12",
     "object-path": "^0.11.4",
     "open": "^8.2.0",
     "semver": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "tar-fs": "^2.1.1",
     "tmp-promise": "^3.0.2",
     "underscore": "^1.12.0",
-    "upath": "^2.0.1",
     "update-notifier": "^5.1.0",
     "yargs": "^17.0.1"
   },


### PR DESCRIPTION
Instead of rewriting file paths when tar-ing this PR copies all app files over to a `build/` directory.
We can then tar this folder for Homey Pro or mount it in the container for Homey Cloud.

This appears to perform reasonably for `com.fibaro` which I think is considered a large app. If performance becomes an issue we could try to avoid copying `node_modules`. I _think_ we can mount it separately inside the docker container and append it to the tar.

Since there where concerns about the performance of copying the files to a folder I measured and optimized the `preprocess()` step:
- `npm prune` turned out to be pretty slow, we can use `npm ls` instead which is faster but gives basically the same result.
- `ignore-walk` doesn't scale well with the number of rules, so instead of ignoring dev dependencies while walking we can ignore `node_modules` and collect the production dependencies separately.