### PR TITLE
fix: safely copy node_modules

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -667,16 +667,43 @@ class App {
     await fse.remove(path.join(this.path, 'build'));
 
     // Copy app source over to build/
-    const sourceFiles = await this._getAppSourceFiles();
-    const dependencies = await NpmCommands.getProductionDependencies({ appPath: this.path });
-
-    await Promise.all(sourceFiles.concat(dependencies).map(filePath => {
-      return fse.copy(path.join(this.path, filePath), path.join(this.path, 'build', filePath));
-    }));
+    await Promise.all([
+      this._copyAppSourceFiles(),
+      this._copyAppProductionDependencies(),
+    ]);
 
     // Compile TypeScript files to build/
     if (App.usesTypeScript({ appPath: this.path })) {
       await App.transpileToTypescript({ appPath: this.path });
+    }
+  }
+
+  async _copyAppSourceFiles() {
+    const sourceFiles = await this._getAppSourceFiles();
+
+    for (const filePath of sourceFiles) {
+      const fullSrc = path.join(this.path, filePath);
+      const fullDest = path.join(this.path, 'build', filePath);
+
+      await fse.copy(fullSrc, fullDest);
+    }
+  }
+
+  async _copyAppProductionDependencies() {
+    const dependencies = await NpmCommands.getProductionDependencies({ appPath: this.path });
+
+    for (const filePath of dependencies) {
+      const fullSrc = path.join(this.path, filePath);
+      const fullDest = path.join(this.path, 'build', filePath);
+
+      await fse.copy(fullSrc, fullDest, {
+        filter(src) {
+          // Do not copy node_modules of dependencies, if we need a sub-dependency it
+          // will itself be listed by `NpmCommands.getProductionDependencies()`
+          const subPath = src.replace(fullSrc, '');
+          return subPath.startsWith('/node_modules') === false;
+        },
+      });
     }
   }
 


### PR DESCRIPTION
Apparently `fs-extra` can race with itself if you use `Promise.all()` so it appears we need to use a `for ... of` loop with an `await`. This unfortunately make it quite a bit slower :(
 
Two small optimisations:
- We can still concurrently copy the app source files and the dependencies (since we know they won't overlap)
- We now ignore _dev dependencies_ of the apps production dependencies, this makes apps smaller and makes copying faster