### PR TITLE
fix: error if package.json is missing

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -690,6 +690,16 @@ class App {
   }
 
   async _copyAppProductionDependencies() {
+    const hasNodeModules = fs.existsSync(path.join(this.path, 'node_modules'));
+    const hasPackageJSON = fs.existsSync(path.join(this.path, 'package.json'));
+
+    if (hasNodeModules === true && hasPackageJSON === false) {
+      throw new Error(
+        'This Homey App contains a node_modules/ folder but has no package.json file.\n'
+        + 'Fix this error by creating a package.json and reinstall your App\'s dependencies',
+      );
+    }
+
     const dependencies = await NpmCommands.getProductionDependencies({ appPath: this.path });
 
     for (const filePath of dependencies) {


### PR DESCRIPTION
`npm ls` needs a `package.json` otherwise it will list nothing.
Since we flipped the way we use this command from "what are the dev dependencies" to "what are the production dependencies" this can cause an app to not include bundle its dependencies.
We can do one of two things:
- Copy the entire `node_modules/` folder (optionally print a warning)
- Error that a `package.json` is missing

This PR implements the second strategy, so that if your app has a `node_modules/` folder it should also include a `package.json`. The reason being that it is probably not intentional to miss a `package.json` file.