### PR TITLE
fix(zwave): accept unauthorized certificates

### DIFF
--- a/lib/ZWave.js
+++ b/lib/ZWave.js
@@ -86,13 +86,13 @@ class ZWave {
     if (Array.isArray(sigmaJson.ConfigurationParameters)) {
       sigmaJson.ConfigurationParameters.forEach(configurationParameter => {
         const settingObj = {};
-        settingObj.id = (String)(configurationParameter.ParameterNumber);
+        settingObj.id = String(configurationParameter.ParameterNumber);
         settingObj.value = configurationParameter.DefaultValue;
         settingObj.label = {
-          en: (String)(configurationParameter.Name),
+          en: String(configurationParameter.Name),
         };
         settingObj.hint = {
-          en: (String)(configurationParameter.Description),
+          en: String(configurationParameter.Description),
         };
 
         settingObj.zwave = {


### PR DESCRIPTION
Since its unlikely the Z-Wave alliance is going to fix this lets just ignore the unauthorized rejections. Not ideal but should be safe.