### PR TITLE
fix: NPM windows 11 newlines

### DIFF
--- a/lib/NpmCommands.js
+++ b/lib/NpmCommands.js
@@ -50,7 +50,7 @@ class NpmCommands {
     const { stdout } = await exec('npm ls --parseable --all --only=prod', { cwd: appPath });
 
     return stdout
-      .split('\n')
+      .split(/\r?\n/)
       .map(filePath => path.relative(appPath, filePath))
       .filter(filePath => filePath !== '');
   }


### PR DESCRIPTION
fixes https://github.com/athombv/homey-apps-sdk-issues/issues/234
Before NPM always used `\n` but apparently it changed in Windows 11.