### PR TITLE
feat: provide app start data

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -466,43 +466,6 @@ class App {
     });
     Log(colors.green('✓ Connected to Homey'));
 
-    const serverIO = SocketIOServer(serverHTTP, {
-      transports: ['websocket'],
-      reconnect: false,
-      pingTimeout: 10000,
-      pingInterval: 30000,
-    });
-    serverIO.on('connection', socket => {
-      socket
-        .on('event', ({ homeyId, ...props }, callback) => {
-          if (homeyId !== homey._id) {
-            return callback('Invalid Homey ID');
-          }
-
-          return clientIO.emit('event', {
-            sessionId,
-            ...props,
-          }, callback);
-        })
-        .emit('createClient', ({
-          homeyId: homey._id,
-        }), err => {
-          if (err) {
-            Log(colors.red('✖ App Crashed. Stack Trace:'));
-            Log(colors.red(err));
-
-            exiting = true;
-            cleanup()
-              .catch(() => {})
-              .finally(() => {
-                process.exit(0);
-              });
-            return homeyIOReject(err);
-          }
-          return homeyIOResolve(socket);
-        });
-    });
-
     // Add Icon Hashes to Manifest
     // App Icon Hash
     manifest.iconHash = await Util.getFileHash(path.join(this.path, 'assets', 'icon.svg'));
@@ -529,16 +492,16 @@ class App {
 
     // Start the App on Homey
     Log(colors.green('✓ Starting app...'));
-    await Promise.race([
+    const startData = await Promise.race([
       new Promise((resolve, reject) => {
         clientIO.emit('start', {
           sessionId,
           manifest,
           homeyId: homey._id,
           appId: manifest.id,
-        }, err => {
+        }, (err, data) => {
           if (err) return reject(new Error(err));
-          return resolve();
+          return resolve(data);
         });
       }),
       new Promise((_, reject) => {
@@ -548,6 +511,45 @@ class App {
       }),
     ]);
     Log(colors.green('✓ Started app'));
+
+    const serverIO = SocketIOServer(serverHTTP, {
+      transports: ['websocket'],
+      reconnect: false,
+      pingTimeout: 10000,
+      pingInterval: 30000,
+    });
+
+    serverIO.on('connection', socket => {
+      socket
+        .on('event', ({ homeyId, ...props }, callback) => {
+          if (homeyId !== homey._id) {
+            return callback('Invalid Homey ID');
+          }
+
+          return clientIO.emit('event', {
+            sessionId,
+            ...props,
+          }, callback);
+        })
+        .emit('createClient', ({
+          ...startData,
+          homeyId: homey._id,
+        }), err => {
+          if (err) {
+            Log(colors.red('✖ App Crashed. Stack Trace:'));
+            Log(colors.red(err));
+
+            exiting = true;
+            cleanup()
+              .catch(() => {})
+              .finally(() => {
+                process.exit(0);
+              });
+            return homeyIOReject(err);
+          }
+          return homeyIOResolve(socket);
+        });
+    });
 
     // Create & Run Container
     const inspectPort = await getPort({


### PR DESCRIPTION
Pass through the "start data" to the `createClient` event. This makes the behaviour of apps more similar to how cloud actually provides this data.