### PR TITLE
rename /build to /.homeybuild, auto-add to .gitignore

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -80,7 +80,7 @@ class App {
     Log(colors.green('✓ Typescript detected. Compiling...'));
 
     try {
-      await exec('npx tsc --outDir build/', { cwd: appPath });
+      await exec('npx tsc --outDir .homeybuild/', { cwd: appPath });
 
       Log(colors.green('✓ Typescript compilation successful'));
     } catch (err) {
@@ -589,7 +589,7 @@ class App {
           ...(HOMEY_APP_RUNNER_SDK_PATH
             ? [`${HOMEY_APP_RUNNER_SDK_PATH}:/homey-app-runner/node_modules/homey-apps-sdk-v3:ro`]
             : []),
-          `${path.join(this.path, 'build')}:/app:ro`,
+          `${path.join(this.path, '.homeybuild')}:/app:ro`,
         ],
       },
     };
@@ -668,18 +668,28 @@ class App {
       await HomeyCompose.build({ appPath: this.path });
     }
 
-    // Clear the build/ folder
-    await fse.remove(path.join(this.path, 'build'));
+    // Clear the .homeybuild/ folder
+    await fse.remove(path.join(this.path, '.homeybuild'));
 
-    // Copy app source over to build/
+    // Copy app source over to .homeybuild/
     await Promise.all([
       this._copyAppSourceFiles(),
       this._copyAppProductionDependencies(),
     ]);
 
-    // Compile TypeScript files to build/
+    // Compile TypeScript files to .homeybuild/
     if (App.usesTypeScript({ appPath: this.path })) {
       await App.transpileToTypescript({ appPath: this.path });
+    }
+
+    // Ensure `/.homeybuild` is added to `.gitignore`, if it exists
+    const gitIgnorePath = path.join(this.path, '.gitignore');
+    if (await fse.pathExists(gitIgnorePath)) {
+      const gitIgnore = await fse.readFile(gitIgnorePath, 'utf8');
+      if (!gitIgnore.includes('.homeybuild')) {
+        Log(colors.green('✓ Automatically added `/.homeybuild/` to .gitignore'));
+        await fse.writeFile(gitIgnorePath, gitIgnore + '\n\n# Added by Homey CLI\n/.homeybuild/');
+      }
     }
   }
 
@@ -688,7 +698,7 @@ class App {
 
     for (const filePath of sourceFiles) {
       const fullSrc = path.join(this.path, filePath);
-      const fullDest = path.join(this.path, 'build', filePath);
+      const fullDest = path.join(this.path, '.homeybuild', filePath);
 
       await fse.copy(fullSrc, fullDest);
     }
@@ -702,7 +712,7 @@ class App {
       // `npm ls` (in getProductionDependencies) needs a package.json to list dependencies
       // If an app has a node_modules folder but no pacakge.json we just copy it wholesale.
       const src = path.join(this.path, 'node_modules');
-      const dest = path.join(this.path, 'build', 'node_modules');
+      const dest = path.join(this.path, '.homeybuild', 'node_modules');
       await fse.copy(src, dest);
       return;
     }
@@ -715,7 +725,7 @@ class App {
 
     for (const filePath of dependencies) {
       const fullSrc = path.join(this.path, filePath);
-      const fullDest = path.join(this.path, 'build', filePath);
+      const fullDest = path.join(this.path, '.homeybuild', filePath);
 
       await fse.copy(fullSrc, fullDest, {
         filter(src) {
@@ -1095,7 +1105,7 @@ class App {
     const tmpFile = await tmp.file();
 
     await pipeline(
-      tar.pack(path.join(this.path, 'build'), { dereference: true }).on('data', chunk => {
+      tar.pack(path.join(this.path, '.homeybuild'), { dereference: true }).on('data', chunk => {
         appSize += chunk.length;
       }),
       zlib.createGzip(),
@@ -1127,11 +1137,11 @@ class App {
 
     const ignoreRules = [
       '.*',
+      '.homeybuild',
       '*.ts',
       'tsconfig.json',
       'env.json',
       '*.compose.json',
-      'build/*',
       'node_modules/*',
     ];
     // Add a "file" containing our default ignore rules for dotfiles, env.json and node_modules
@@ -2601,7 +2611,9 @@ class App {
 
     await App.addTypes({ appPath });
 
-    const gitIgnore = 'env.json\nnode_modules/\nbuild/';
+    const gitIgnore = `/env.json
+/node_modules/
+/.homeybuild/`;
 
     await writeFileAsync(path.join(appPath, '.gitignore'), gitIgnore.toString());
 
@@ -2620,7 +2632,7 @@ class App {
       extends: '@tsconfig/node12/tsconfig.json',
       compilerOptions: {
         allowJs: true,
-        outDir: 'build/',
+        outDir: '.homeybuild/',
       },
     };
 


### PR DESCRIPTION
Currently, developers with existing apps have an unexpected `build` folder in their Git diff and they are unsure whether it's safe to remove.

I've also renamed it to `.homeybuild` for consistency.