### PR TITLE
add --link-modules to homey app run

### DIFF
--- a/bin/cmds/app/run.js
+++ b/bin/cmds/app/run.js
@@ -16,6 +16,12 @@ exports.builder = yargs => {
       alias: 's',
       type: 'boolean',
       default: false,
+    })
+    .option('link-modules', {
+      alias: 'l',
+      type: 'string',
+      default: '',
+      desc: 'Provide a comma-separated path to local Node.js modules to link. Only works on Homey Cloud.',
     });
 };
 exports.handler = async yargs => {
@@ -24,6 +30,7 @@ exports.handler = async yargs => {
     await app.run({
       clean: yargs.clean,
       skipBuild: yargs.skipBuild,
+      linkModules: yargs.linkModules,
     });
   } catch (err) {
     Log(colors.red(err.message));

--- a/lib/App.js
+++ b/lib/App.js
@@ -122,6 +122,7 @@ class App {
   async run({
     clean = false,
     skipBuild = false,
+    linkModules = '',
   } = {}) {
     const homey = await AthomApi.getActiveHomey();
     if (homey.apiVersion >= 3) {
@@ -129,6 +130,7 @@ class App {
         homey,
         clean,
         skipBuild,
+        linkModules,
       });
     }
     return this.runRemote({
@@ -190,6 +192,7 @@ class App {
     homey,
     clean,
     skipBuild,
+    linkModules,
   }) {
     // Prepare Docker
     const docker = new Docker();
@@ -590,6 +593,14 @@ class App {
             ? [`${HOMEY_APP_RUNNER_SDK_PATH}:/homey-app-runner/node_modules/homey-apps-sdk-v3:ro`]
             : []),
           `${path.join(this.path, '.homeybuild')}:/app:ro`,
+
+          ...(linkModules.split(',')
+            .filter(linkModule => !!linkModule)
+            .map(linkModule => {
+              const linkedModulePath = linkModule.trim();
+              const { name } = fse.readJSONSync(path.join(linkedModulePath, 'package.json'));
+              return `${linkedModulePath}:/app/node_modules/${name}:ro`;
+            })),
         ],
       },
     };

--- a/lib/App.js
+++ b/lib/App.js
@@ -594,6 +594,8 @@ class App {
             : []),
           `${path.join(this.path, '.homeybuild')}:/app:ro`,
 
+          // Link Node.js modules as Docker binds.
+          // Note that we need to read the `name` from the module's package.json to create a correct path.
           ...(linkModules.split(',')
             .filter(linkModule => !!linkModule)
             .map(linkModule => {


### PR DESCRIPTION
When running a Docker container (Homey Cloud), it wasn't possible to use `npm link`-ed modules inside, because the build would fail.

The argument `homey app run --link-modules ~/Git/node-my-module` now binds `~/Git/node-my-module` to `/app/node_modules/my-module`, which makes the life of a developer _also_ developing a Node.js module much better.