### PR TITLE
Add option to app run command for specifying Docker network

### DIFF
--- a/bin/cmds/app/run.js
+++ b/bin/cmds/app/run.js
@@ -29,6 +29,12 @@ exports.builder = yargs => {
       type: 'string',
       default: '',
       desc: 'Provide a comma-separated path to local Node.js modules to link. Only works when running the app inside Docker.',
+    })
+    .option('network', {
+      alias: 'n',
+      default: 'bridge',
+      type: 'string',
+      description: 'Docker network mode. Must match name from `docker network ls`. Only works when running the app inside Docker.',
     });
 };
 exports.handler = async yargs => {
@@ -39,6 +45,7 @@ exports.handler = async yargs => {
       clean: yargs.clean,
       skipBuild: yargs.skipBuild,
       linkModules: yargs.linkModules,
+      network: yargs.network
     });
   } catch (err) {
     if (err instanceof Error && err.stack) {

--- a/lib/App.js
+++ b/lib/App.js
@@ -132,6 +132,7 @@ class App {
     remote = false,
     skipBuild = false,
     linkModules = '',
+    network = 'bridge',
   } = {}) {
     const homey = await AthomApi.getActiveHomey();
 
@@ -158,6 +159,7 @@ class App {
       clean,
       skipBuild,
       linkModules,
+      network,
     });
   }
 
@@ -201,6 +203,7 @@ class App {
     clean,
     skipBuild,
     linkModules,
+    network,
   }) {
     // Prepare Docker
     const docker = new Docker();
@@ -674,7 +677,7 @@ class App {
       },
       HostConfig: {
         ReadonlyRootfs: true,
-        NetworkMode: 'bridge',
+        NetworkMode: network,
         PortBindings: {
           [`${inspectPort}/tcp`]: [{
             HostPort: String(inspectPort),


### PR DESCRIPTION
Allows running app during local development with host networking, which is required for UDP multicast, which some apps use for device discovery.

On non-Linux systems this requires a Docker setup that bridges the Docker VM with the host, for example Colima in combination with socket_vmnet, as documented e.g:

 * https://blog.illixion.com/2023/04/colima-home-assistant/
 * https://baptistout.net/posts/kubernetes-clusters-on-macos-with-loadbalancer-without-docker-desktop/
 * https://github.com/lima-vm/socket_vmnet