### PR TITLE
feat: allow for custom homey config directory

### DIFF
--- a/lib/Settings.js
+++ b/lib/Settings.js
@@ -26,6 +26,10 @@ class Settings {
       return path.join(process.env.APPDATA, 'athom-cli');
     }
 
+    if (process.env.HOMEY_HOME) {
+      return process.env.HOMEY_HOME;
+    }
+
     return path.join(process.env.HOME, '.athom-cli');
   }
 


### PR DESCRIPTION
I like to keep my home directory clean, therefore directories like `.athom-cli` in the home directory clutters it up, and it would be nice to set the directory with environment variables.