### PR TITLE
fix(docker): Docker Desktop compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "cli-table": "^0.3.5",
         "colors": "^1.1.2 <=1.4.0",
         "deepmerge": "^4.2.2",
-        "dockerode": "^3.3.4",
+        "dockerode": "^4.0.0",
         "eslint": "^6.8.0",
         "express": "^4.16.4",
         "figures": "^3.2.0",
@@ -466,9 +466,9 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -670,6 +670,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bytes": {
@@ -1006,6 +1015,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cpu-features": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
+      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.17.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1140,26 +1163,26 @@
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
     },
     "node_modules/docker-modem": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.0.tgz",
-      "integrity": "sha512-WwFajJ8I5geZ/dDZ5FDMDA6TBkWa76xWwGIGw8uzUjNUGCN0to83wJ8Oi1AxrJTC0JBn+7fvIxUctnawtlwXeg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.1.tgz",
+      "integrity": "sha512-vqrE/nrweCyzmCpVpdFRC41qS+tfTF+IoUKlTZr52O82urbUqdfyJBGWMvT01pYUprWepLr8IkyVTEWJKRTQSg==",
       "dependencies": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
         "split-ca": "^1.0.1",
-        "ssh2": "^0.8.7"
+        "ssh2": "^1.11.0"
       },
       "engines": {
         "node": ">= 8.0"
       }
     },
     "node_modules/dockerode": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.4.tgz",
-      "integrity": "sha512-3EUwuXnCU+RUlQEheDjmBE0B7q66PV9Rw5NiH1sXwINq0M9c5ERP9fxgkw36ZHOtzf4AGEEYySnkx/sACC9EgQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.0.tgz",
+      "integrity": "sha512-3LF7/3MPz5+9RsUo91rD0MCcx0yxjC9bnbtgtVjOLKyKxlZSJ7/Kk3OPAgARlwlWHqXwAGYhmkAHYx7IwD0tJQ==",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "docker-modem": "^3.0.0",
+        "docker-modem": "^5.0.0",
         "tar-fs": "~2.0.1"
       },
       "engines": {
@@ -3285,6 +3308,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "node_modules/nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4307,27 +4336,20 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/ssh2": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.14.0.tgz",
+      "integrity": "sha512-AqzD1UCqit8tbOKoj6ztDDi1ffJZ2rV2SwlgrVVrHPkV5vWqGJOVp5pmtj18PunkPJAuKQsnInyKV+/Nb2bUnA==",
+      "hasInstallScript": true,
       "dependencies": {
-        "ssh2-streams": "~0.4.10"
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
       },
       "engines": {
-        "node": ">=5.2.0"
-      }
-    },
-    "node_modules/ssh2-streams": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-      "dependencies": {
-        "asn1": "~0.2.0",
-        "bcrypt-pbkdf": "^1.0.2",
-        "streamsearch": "~0.1.2"
+        "node": ">=10.16.0"
       },
-      "engines": {
-        "node": ">=5.2.0"
+      "optionalDependencies": {
+        "cpu-features": "~0.0.8",
+        "nan": "^2.17.0"
       }
     },
     "node_modules/statuses": {
@@ -4336,14 +4358,6 @@
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cli-table": "^0.3.5",
     "colors": "^1.1.2 <=1.4.0",
     "deepmerge": "^4.2.2",
-    "dockerode": "^3.3.4",
+    "dockerode": "^4.0.0",
     "eslint": "^6.8.0",
     "express": "^4.16.4",
     "figures": "^3.2.0",


### PR DESCRIPTION
This fixes the following issue that I encountered on my setup (MacOS Sonoma + Docker Desktop v4.25.0). The dockerode update seems to be a major update but there is no changelog provided. Checked the source code changes (see links below) but couldn't find anything worrying.

```
homey app run
connect ENOENT /var/run/docker.sock
✖ Error: Could not connect to Docker. Is it running?
If you haven't installed Docker yet, please download & install it first:

   https://docs.docker.com/docker-for-mac/install/
    at /Users/robinbolscher/development/node-homey/lib/App.js:227:13
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async App.runDocker (/Users/robinbolscher/development/node-homey/lib/App.js:210:5)
    at async Object.exports.handler (/Users/robinbolscher/development/node-homey/bin/cmds/app/run.js:43:5)
```

- dockerode changes: https://github.com/apocas/dockerode/compare/v3.3.4..v4.0.0
- Relevant commit in dockerode dependency docker-modem that fixes this issue: https://github.com/apocas/docker-modem/commit/0c65c9a3745c6a743e0cdaa6d1a64a0e8f816f95