### PR TITLE
NpmCommands: filter out production deps that are parents of app path

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -874,35 +874,52 @@ $ sudo systemctl restart docker
         throw new Error('This error may be fixed by running `npm install` in your app.');
       });
 
-    for (const filePath of dependencies) {
-      console.log('path', this.path);
-      console.log('homeyBuildPath', this._homeyBuildPath);
-      console.log('dependency', filePath);
+    console.log('dependencies', dependencies);
 
+    for (const filePath of dependencies) {
       const fullSrc = path.join(this.path, filePath);
 
       // Root the destination path to ensure it does not break out of the
-      // .homeybuild path. This is necessary when the dependency resides in a
-      // node_modules directory above the app path in the filesystem.
-      const destPath = filePath.split(path.sep).filter(segment => segment !== '..').join(path.sep);
+      // `.homeybuild` path. This is necessary when the dependency resides in
+      // a `node_modules` directory above the app path in the filesystem.
+      let destPath = filePath.split(path.sep).filter(segment => segment !== '..').join(path.sep);
 
+      // If there is no `node_modules` in the path that means we're probably in
+      // a multi-package repository and the dependency resides somewhere else
+      // in the repo. Read the package name from package.json to determine
+      // where it should be copied under `node_modules` in `.homeybuild`.
+      //
+      // Use the basename of the directory as the package
+      // directory under `node_modules` in the `.homeybuild` path.
+      if (!destPath.includes('node_modules')) {
+        let { name } = fse.readJSONSync(path.join(filePath, 'package.json'));
+        // Account for scoped packages like @mycompany/package.
+        if (name.includes('/')) {
+          name = name.split('/').join(path.sep);
+        }
+
+        destPath = path.join('node_modules', name);
+      // If the destination path does include `node_modules`, but it's not the
+      // prefix in the path that means we're probably looking at a
+      // dependency of another multi-package repository package. In this
+      // case remove the package prefix up to the first `node_modules` in
+      // the path to ensure the sub-dependency gets dropped in the
+      // `homeybuild` `node_modules` as well.
+      } else if (!destPath.startsWith('node_modules')) {
+        destPath = destPath.slice(destPath.indexOf('node_modules'));
+      }
+
+      console.log('destpath', destPath);
       const fullDest = path.join(this._homeyBuildPath, destPath);
-
-      console.log('copy dependencies from', fullSrc, 'to', fullDest);
 
       await fse.copy(fullSrc, fullDest, {
         filter(src) {
-          console.log('copy from', src);
           // Do not copy node_modules of dependencies, if we need a sub-dependency it
           // will itself be listed by `NpmCommands.getProductionDependencies()`
           const subPath = src.replace(fullSrc, '');
-          console.log('subpath', subPath);
 
           // The first character is either `/` or `\` so we start looking at position 1
-          const shouldCopy = subPath.startsWith('node_modules', 1) === false;
-          console.log('should copy?', shouldCopy);
-
-          return shouldCopy;
+          return subPath.startsWith('node_modules', 1) === false;
         },
       });
     }

--- a/lib/App.js
+++ b/lib/App.js
@@ -875,16 +875,34 @@ $ sudo systemctl restart docker
       });
 
     for (const filePath of dependencies) {
+      console.log('path', this.path);
+      console.log('homeyBuildPath', this._homeyBuildPath);
+      console.log('dependency', filePath);
+
       const fullSrc = path.join(this.path, filePath);
-      const fullDest = path.join(this._homeyBuildPath, filePath);
+
+      // Root the destination path to ensure it does not break out of the
+      // .homeybuild path. This is necessary when the dependency resides in a
+      // node_modules directory above the app path in the filesystem.
+      const destPath = filePath.split(path.sep).filter(segment => segment !== '..').join(path.sep);
+
+      const fullDest = path.join(this._homeyBuildPath, destPath);
+
+      console.log('copy dependencies from', fullSrc, 'to', fullDest);
 
       await fse.copy(fullSrc, fullDest, {
         filter(src) {
+          console.log('copy from', src);
           // Do not copy node_modules of dependencies, if we need a sub-dependency it
           // will itself be listed by `NpmCommands.getProductionDependencies()`
           const subPath = src.replace(fullSrc, '');
+          console.log('subpath', subPath);
+
           // The first character is either `/` or `\` so we start looking at position 1
-          return subPath.startsWith('node_modules', 1) === false;
+          const shouldCopy = subPath.startsWith('node_modules', 1) === false;
+          console.log('should copy?', shouldCopy);
+
+          return shouldCopy;
         },
       });
     }

--- a/lib/NpmCommands.js
+++ b/lib/NpmCommands.js
@@ -48,10 +48,12 @@ class NpmCommands {
     // The --package-lock-only flag prevents this but then it will throw when there is no lock file.
     const { stdout } = await exec('npm ls --parseable --all --only=prod', { cwd: appPath });
 
+    const regexp = new RegExp(`^(\\.\\.\\${path.sep}?)*$`);
+
     return stdout
       .split(/\r?\n/)
       .map(filePath => path.relative(appPath, fs.realpathSync(filePath)))
-      .filter(filePath => !filePath.match(/^(\.\.\/?)*$/));
+      .filter(filePath => !filePath.match(regexp));
   }
 
 }

--- a/lib/NpmCommands.js
+++ b/lib/NpmCommands.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const childProcess = require('child_process');
@@ -49,7 +50,7 @@ class NpmCommands {
 
     return stdout
       .split(/\r?\n/)
-      .map(filePath => path.relative(appPath, filePath))
+      .map(filePath => path.relative(appPath, fs.realpathSync(filePath)))
       .filter(filePath => !filePath.match(/^(\.\.\/?)*$/));
   }
 

--- a/lib/NpmCommands.js
+++ b/lib/NpmCommands.js
@@ -50,7 +50,7 @@ class NpmCommands {
     return stdout
       .split(/\r?\n/)
       .map(filePath => path.relative(appPath, filePath))
-      .filter(filePath => filePath !== '');
+      .filter(filePath => !filePath.match(/^(\.\.\/?)*$/));
   }
 
 }


### PR DESCRIPTION
This gets us a step closer (all the way, maybe?) to being able to use npm workspaces for multiple apps in the same repo.

For context, I have multiple Homey apps that I'm writing for various devices and services and I would like to keep them all in a single monorepo and share the `node_modules` between them.

I've got this mostly working using [turbo](https://turbo.build) and the `--path` argument on the `homey` CLI, but `build` currently explodes because the first path in the list returned from [`npm ls`](https://github.com/athombv/node-homey/blob/master/lib/NpmCommands.js#L48) is the root of the monorepo.

It [doesn't get filtered out](https://github.com/athombv/node-homey/blob/master/lib/NpmCommands.js#L53) because it's not the `appPath` itself, but it does contain a *direct* parent because some of the `node_modules` exist outside of the `appPath` directory in the `node_modules` at the root of the monorepo. This parent path gets passed back to [`_copyAppProductionDependencies`](https://github.com/athombv/node-homey/blob/master/lib/App.js#L858) where it attempts to copy the parent directory into a subdirectory of itself which explodes with an error that looks like this:
```
com.company.myapp:build: ✓ Building app...
com.company.myapp:build: ✓ Pre-processing app...
com.company.myapp:build: Added Driver `MY-DRIVER`
com.company.myapp:build: ✖ Cannot copy '../apps/com.company.myapp' to a subdirectory of itself, '../apps/com.company.myap'.
com.company.myapp:build: npm ERR! Lifecycle script `build` failed with error: 
com.company.myapp:build: npm ERR! Error: command failed 
com.company.myapp:build: npm ERR!   in workspace: com.company.myapp@1.0.0 
com.company.myapp:build: npm ERR!   at location: /monorepo/apps/com.company.myapp 
com.company.myapp:build: ERROR: command finished with error: command (/monorepo/apps/com.company.myapp) /usr/local/bin/npm run build exited (1)
Cannot copy cannot copy a directory, 'monorepo', into itself, 'monorepo/apps/com.company.app'
```

This change does two things:
1. filters out any paths that look like `..` or `../..` indicating that the relative path is a direct parent of the `appPath` in addition to maintaining the existing behavior of also filtering out the `appPath` itself.
2. uses `fs` to read the real path which is critical because it resolves symlinks which is necessary to avoid the self-copying when the package in the root `node_modules` points to the package that you're building.