### PR TITLE
Support app development environments that use podman rootless containers

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -227,6 +227,11 @@ class App {
       throw new Error(`Could not connect to Docker. Is it running?\nIf you haven't installed Docker yet, please download & install it first:\n\n   ${dockerUrl}`);
     });
 
+    const containerVersionInfo = await docker.version();
+    const isPodmanEngine = containerVersionInfo.Components
+      ? containerVersionInfo.Components.some(component => component.Name === 'Podman Engine')
+      : false;
+
     // Build the App
     if (skipBuild) {
       Log(colors.yellow('\n⚠ Skipping build steps!\n'));
@@ -642,6 +647,8 @@ class App {
       serverApp.use('/userdata/', express.static(userdataDir));
     }
 
+    const defaultHostLinux = isPodmanEngine ? 'host.containers.internal' : '172.17.0.1';
+
     // Create & Run Container
     // eslint-disable-next-line no-nested-ternary
     const host = (process.platform === 'linux')
@@ -652,7 +659,7 @@ class App {
             return resolve(stdout.trim());
           });
         })
-        : '172.17.0.1'
+        : defaultHostLinux
       : 'host.docker.internal';
 
     const createOpts = {

--- a/lib/App.js
+++ b/lib/App.js
@@ -685,24 +685,24 @@ class App {
         },
         Binds: [
           ...(HOMEY_APP_RUNNER_PATH
-            ? [`${HOMEY_APP_RUNNER_PATH}:/homey-app-runner:ro`]
+            ? [`${HOMEY_APP_RUNNER_PATH}:/homey-app-runner:ro,z`]
             : []),
           ...(HOMEY_APP_RUNNER_SDK_PATH
-            ? [`${HOMEY_APP_RUNNER_SDK_PATH}:/homey-app-runner/node_modules/@athombv/homey-apps-sdk-v3:ro`]
+            ? [`${HOMEY_APP_RUNNER_SDK_PATH}:/homey-app-runner/node_modules/@athombv/homey-apps-sdk-v3:ro,z`]
             : []),
-          `${this._homeyBuildPath}:/app:ro`,
+          `${this._homeyBuildPath}:/app:ro,z`,
 
           // Mount /userdata & /tmp for Homey Pro
           ...(homey.platform === 'local'
             ? [
-              `${tmpDir}:/tmp:rw`,
-              `${userdataDir}:/userdata:rw`,
+              `${tmpDir}:/tmp:rw,z`,
+              `${userdataDir}:/userdata:rw,z`,
             ]
             : []),
 
           // Link Node.js modules as Docker binds.
           // Note that we need to read the `name` from the module's package.json to create a correct path.
-          `${path.join(this._homeyBuildPath, 'node_modules')}:/app/node_modules/:rw`,
+          `${path.join(this._homeyBuildPath, 'node_modules')}:/app/node_modules/:rw,z`,
           ...(linkModules.split(',')
             .filter(linkModule => !!linkModule)
             .map(linkModule => {


### PR DESCRIPTION
The following changes are included in this PR.

1. Support the use of SELinux labeling for volume binds when creating containers. As without this, the source file is not correctly loaded when `homey app run` is executed. See blow logs for details on issue.

<details>
<summary><b>home-app-run.log</b></summary>
<p>

```console
{"stream":true,"stdout":true,"stderr":true}Debugger listening on ws://0.0.0.0:9229/XXXX
For help, see: https://nodejs.org/en/docs/inspector
node:internal/modules/cjs/loader:1029
  throw err;
  ^

Error: Cannot find module '/app/app.json'
Require stack:
- /homey-app-runner/lib/App.js
- /homey-app-runner/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1026:15)
    at Function.Module._load (node:internal/modules/cjs/loader:871:27)
    at Module.require (node:internal/modules/cjs/loader:1098:19)
    at Module.homeyRequire [as require] (/node_modules/@athombv/homey-apps-sdk-v3/index.js:12:19)
    at require (node:internal/modules/cjs/helpers:108:18)
    at new App (/homey-app-runner/lib/App.js:68:21)
    at Object.<anonymous> (/homey-app-runner/index.js:15:18)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/homey-app-runner/lib/App.js', '/homey-app-runner/index.js' ]
}
```

</p>
</details>

2. Detect the use of [podman](https://podman.io) and use `host.containers.internal` instead of `172.17.0.1` as default host. See following log for error.

<details>
<summary><b>home-app-run.log</b></summary>
<p>

```console
{"stream":true,"stdout":true,"stderr":true}Debugger listening on ws://0.0.0.0:9229/XXX
For help, see: https://nodejs.org/en/docs/inspector
2024-02-08T12:21:28.199Z Could not connect to Homey (ws://172.17.0.1:30000).
2024-02-08T12:21:28.200Z Error: websocket error
    at WS.onError (/node_modules/engine.io-client/lib/transport.js:29:17)
    at WebSocket.ws.onerror (/node_modules/engine.io-client/lib/transports/websocket.js:112:33)
    at WebSocket.onError (/node_modules/ws/lib/event-target.js:140:16)
    at WebSocket.emit (node:events:513:28)
    at abortHandshake (/node_modules/ws/lib/websocket.js:731:15)
    at WebSocket.close (/node_modules/ws/lib/websocket.js:224:14)
    at WS.doClose (/node_modules/engine.io-client/lib/transports/websocket.js:189:15)
    at WS.close (/node_modules/engine.io-client/lib/transport.js:57:12)
    at Socket.onClose (/node_modules/engine.io-client/lib/socket.js:618:22)
    at close (/node_modules/engine.io-client/lib/socket.js:547:12) {
  type: 'TransportError',
  description: ErrorEvent {
    target: WebSocket {
      _events: [Object: null prototype],
      _eventsCount: 4,
      _maxListeners: undefined,
      _binaryType: 'nodebuffer',
      _closeCode: 1006,
      _closeFrameReceived: false,
      _closeFrameSent: false,
      _closeMessage: '',
      _closeTimer: null,
      _extensions: {},
      _protocol: '',
      _readyState: 2,
      _receiver: null,
      _sender: null,
      _socket: null,
      _bufferedAmount: 0,
      _isServer: false,
      _redirects: 0,
      _url: 'ws://172.17.0.1:30000/socket.io/?EIO=4&transport=websocket',
      _req: [ClientRequest],
      [Symbol(kCapture)]: false
    },
    type: 'error',
    message: 'WebSocket was closed before the connection was established',
    error: Error: WebSocket was closed before the connection was established
        at WebSocket.close (/node_modules/ws/lib/websocket.js:224:14)
        at WS.doClose (/node_modules/engine.io-client/lib/transports/websocket.js:189:15)
        at WS.close (/node_modules/engine.io-client/lib/transport.js:57:12)
        at Socket.onClose (/node_modules/engine.io-client/lib/socket.js:618:22)
        at close (/node_modules/engine.io-client/lib/socket.js:547:12)
        at Socket.close (/node_modules/engine.io-client/lib/socket.js:578:9)
        at Timeout.<anonymous> (/node_modules/socket.io-client/build/manager.js:146:24)
        at listOnTimeout (node:internal/timers:559:17)
        at processTimers (node:internal/timers:502:7)
  }
}
```

</p>
</details>