### PR TITLE
introduce optional DOCKER_HOST_GATEWAY env var

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -652,7 +652,7 @@ class App {
             return resolve(stdout.trim());
           });
         })
-        : '172.17.0.1'
+        : process.env.DOCKER_HOST_GATEWAY || '172.17.0.1'
       : 'host.docker.internal';
 
     const createOpts = {


### PR DESCRIPTION
This change allows to use of `DOCKER_HOST_GATEWAY` to specify host gateway address in scenarios where the hardcoded default bridge IP is not usable.

For example, Linux podman environments can use `host.containers.internal`.

This is based on the comment at https://github.com/athombv/node-homey/pull/371#issuecomment-1943382747.

Note that `DOCKER_HOST_GATEWAY` is not a widely used name as there seems to be no real widely used env var to refer to the gateway IP outside of `host.[docker|containers].internal` alias.