### PR TITLE
update docker bind opts to support selinux labels

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -685,24 +685,24 @@ class App {
         },
         Binds: [
           ...(HOMEY_APP_RUNNER_PATH
-            ? [`${HOMEY_APP_RUNNER_PATH}:/homey-app-runner:ro`]
+            ? [`${HOMEY_APP_RUNNER_PATH}:/homey-app-runner:ro,z`]
             : []),
           ...(HOMEY_APP_RUNNER_SDK_PATH
-            ? [`${HOMEY_APP_RUNNER_SDK_PATH}:/homey-app-runner/node_modules/@athombv/homey-apps-sdk-v3:ro`]
+            ? [`${HOMEY_APP_RUNNER_SDK_PATH}:/homey-app-runner/node_modules/@athombv/homey-apps-sdk-v3:ro,z`]
             : []),
-          `${this._homeyBuildPath}:/app:ro`,
+          `${this._homeyBuildPath}:/app:ro,z`,
 
           // Mount /userdata & /tmp for Homey Pro
           ...(homey.platform === 'local'
             ? [
-              `${tmpDir}:/tmp:rw`,
-              `${userdataDir}:/userdata:rw`,
+              `${tmpDir}:/tmp:rw,z`,
+              `${userdataDir}:/userdata:rw,z`,
             ]
             : []),
 
           // Link Node.js modules as Docker binds.
           // Note that we need to read the `name` from the module's package.json to create a correct path.
-          `${path.join(this._homeyBuildPath, 'node_modules')}:/app/node_modules/:rw`,
+          `${path.join(this._homeyBuildPath, 'node_modules')}:/app/node_modules/:rw,z`,
           ...(linkModules.split(',')
             .filter(linkModule => !!linkModule)
             .map(linkModule => {


### PR DESCRIPTION
This change updates the docker run volume bind options to include the 'z' flag to support systems that have SELinux enabled.

This option is ignored in environments that do not have SELinux enabled.

Reference: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

This is broken out of #371 for evaluation as discussed there with @WeeJeWel.