### PR TITLE
Skip root directory file from translate

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -3101,19 +3101,17 @@ You can create an API Key on https://platform.openai.com/api-keys.`);
             if (file === 'locales') return;
             if (file === 'node_modules') return;
             if (file === '.homeybuild') return;
-            if (file === '.homeycompose') {
-              jsonFiles.add(path.normalize(`${filePath}/app.json`));
-            }
 
             await walkSync(filePath);
           }
 
+          if (dir === this.path) {
+            // Skip root directory files
+            return;
+          }
+
           if (fileStats.isFile() && filePath.endsWith('.json')) {
             if (file.startsWith('.')) return;
-            if (file === 'app.json') return;
-            if (file === 'env.json') return;
-            if (file === 'package.json') return;
-            if (file === 'package-lock.json') return;
 
             jsonFiles.add(path.normalize(filePath));
           }


### PR DESCRIPTION
Skips all files from the root directory when searching for files to translate.