### PR TITLE
Add option to commit/tag/push changes made with version command

### DIFF
--- a/bin/cmds/app/version.js
+++ b/bin/cmds/app/version.js
@@ -15,6 +15,9 @@ exports.builder = yargs => {
       default: null,
       type: 'string',
       description: 'What\'s new in this version?',
+    })
+    .option('commit', {
+      description: 'Create a git commit and tag for the new version',
     });
 };
 exports.handler = async yargs => {
@@ -24,6 +27,10 @@ exports.handler = async yargs => {
 
     if (yargs.changelog) {
       await app.changelog(yargs.changelog);
+    }
+
+    if (yargs.commit) {
+      await app.commit(yargs.changelog);
     }
 
     process.exit(0);

--- a/lib/App.js
+++ b/lib/App.js
@@ -1001,6 +1001,116 @@ $ sudo systemctl restart docker
     Log.success(`Updated changelog for version \`${version}\``);
   }
 
+  async commit(changelog) {
+    if (await GitCommands.isGitInstalled() && await GitCommands.isGitRepo({ path: this.path })) {
+      // Check whether only app.json or also .homeycompose/app.json needs to be committed
+      const commitFiles = [];
+      commitFiles.push(path.join(this.path, 'app.json'));
+      if (await fse.exists(path.join(this._homeyComposePath, 'app.json'))) {
+        commitFiles.push(path.join(this._homeyComposePath, 'app.json'));
+      }
+
+      // Retrieve updated version
+      const { version } = App.getManifest({ appPath: this.path });
+
+      const hasChangelog = !!changelog;
+      if (hasChangelog) {
+        commitFiles.push(path.join(this.path, '.homeychangelog.json'));
+
+        changelog = {en: changelog};
+      } else {
+        // Retrieve from changelog file
+        const changelogJsonPath = path.join(this.path, '.homeychangelog.json');
+        const changelogJson = (await fse.pathExists(changelogJsonPath))
+          ? await fse.readJson(changelogJsonPath)
+          : {};
+
+        changelog = changelogJson[version];
+      }
+
+      // Commit the changes
+      await this._commitChanges(true, hasChangelog, commitFiles, version, changelog, true);
+    } else {
+      throw new Error('A git executable or repository was not found, could not commit version bump');
+    }
+  }
+
+  async _commitChanges(bumpedVersion, updatedChangelog, commitFiles, appVersion, changelog, skipCommitQuestion = false) {
+    let createdGitTag = false;
+    // Only commit and tag if version is bumped
+    if (bumpedVersion) {
+      // First ask if version bump is desired
+      const shouldCommit = skipCommitQuestion || await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'value',
+          message: `Do you want to commit the version bump ${updatedChangelog ? 'and updated changelog' : ''}?`,
+          default: true,
+        },
+      ]);
+
+      // Check if commit is desired
+      if (skipCommitQuestion || shouldCommit.value) {
+        // If version is bumped via wizard and changelog is changed via wizard
+        // then commit all at once
+        if (updatedChangelog) {
+          await this._git.commitFiles({
+            files: commitFiles,
+            message: `Bump version to v${appVersion}`,
+            description: `Changelog: ${changelog['en']}`,
+          });
+          Log.success(`Committed ${commitFiles.map(i => i.replace(`${this.path}/`, ''))
+            .join(', and ')} with version bump`);
+        } else {
+          await this._git.commitFiles({
+            files: commitFiles,
+            message: `Bump version to v${appVersion}`,
+          });
+          Log.success(`Committed ${commitFiles.map(i => i.replace(`${this.path}/`, ''))
+            .join(', and ')} with version bump`);
+        }
+
+        try {
+          if (await this._git.hasUncommittedChanges()) {
+            throw new Error('There are uncommitted or untracked files in this git repository');
+          }
+
+          await this._git.createTag({
+            version: appVersion,
+            message: changelog['en'],
+          });
+
+          Log.success(`Successfully created Git tag \`${appVersion}\``);
+          createdGitTag = true;
+        } catch (error) {
+          Log.warning(`Warning: could not create git tag (v${appVersion}), reason:`);
+          Log.info(error);
+        }
+      }
+    }
+
+    if (await this._git.hasRemoteOrigin() && bumpedVersion) {
+      const answers = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'push',
+          message: 'Do you want to push the local changes to `remote "origin"`?',
+          default: false,
+        },
+      ]);
+
+      if (answers.push) {
+        // First push tag
+        if (createdGitTag) await this._git.pushTag({ version: appVersion });
+
+        // Push all staged changes
+        await this._git.push();
+
+        Log.success('Successfully pushed changes to remote.');
+      }
+    }
+  }
+
   async publish() {
     const undos = {
       version: null,
@@ -1230,76 +1340,7 @@ $ sudo systemctl restart docker
 
       // Commit the version bump and/or changelog to Git if the current path is a repo
       if (await GitCommands.isGitInstalled() && await GitCommands.isGitRepo({ path: this.path })) {
-        let createdGitTag = false;
-        // Only commit and tag if version is bumped
-        if (bumpedVersion) {
-        // First ask if version bump is desired
-          const shouldCommit = await inquirer.prompt([
-            {
-              type: 'confirm',
-              name: 'value',
-              message: `Do you want to commit ${bumpedVersion ? 'the version bump' : ''} ${updatedChangelog ? 'and updated changelog' : ''}?`,
-              default: true,
-            },
-          ]);
-
-          // Check if commit is desired
-          if (shouldCommit.value) {
-          // If version is bumped via wizard and changelog is changed via wizard
-          // then commit all at once
-            if (updatedChangelog) {
-              await this._git.commitFiles({
-                files: commitFiles,
-                message: `Bump version to v${appVersion}`,
-                description: `Changelog: ${changelog['en']}`,
-              });
-              Log.success(`Committed ${commitFiles.map(i => i.replace(`${this.path}/`, '')).join(', and ')} with version bump`);
-            } else {
-              await this._git.commitFiles({
-                files: commitFiles,
-                message: `Bump version to v${appVersion}`,
-              });
-              Log.success(`Committed ${commitFiles.map(i => i.replace(`${this.path}/`, '')).join(', and ')} with version bump`);
-            }
-
-            try {
-              if (await this._git.hasUncommittedChanges()) {
-                throw new Error('There are uncommitted or untracked files in this git repository');
-              }
-
-              await this._git.createTag({
-                version: appVersion,
-                message: changelog['en'],
-              });
-
-              Log.success(`Successfully created Git tag \`${appVersion}\``);
-              createdGitTag = true;
-            } catch (error) {
-              Log.warning(`Warning: could not create git tag (v${appVersion}), reason:`);
-              Log.info(error);
-            }
-          }
-        }
-
-        if (await this._git.hasRemoteOrigin() && bumpedVersion) {
-          const answers = await inquirer.prompt([
-            {
-              type: 'confirm',
-              name: 'push',
-              message: 'Do you want to push the local changes to `remote "origin"`?',
-              default: false,
-            },
-          ]);
-
-          if (answers.push) {
-          // First push tag
-            if (createdGitTag) await this._git.pushTag({ version: appVersion });
-
-            // Push all staged changes
-            await this._git.push();
-            Log.success('Successfully pushed changes to remote.');
-          }
-        }
+        await this._commitChanges(bumpedVersion, updatedChangelog, commitFiles, appVersion, changelog);
       }
       Log.success(`App ${appId}@${appVersion} successfully uploaded.`);
       Log(colors.white(`\nVisit https://tools.developer.homey.app/apps/app/${appId}/build/${buildId} to publish your app.`));


### PR DESCRIPTION
As we mainly use Gitlab it is more convenient to create the version update and tag locally by executing the version command. Adding the option to commit, tag and push the changes made by the version bump greatly helps our workflow.

The `_commitChanges` method is just a refactor from what was already used by the publish command, with an additional option which skips the "do you want to commit question" as that is already answered by supplying the command option.