### PR TITLE
Fix logging when Error object is fed to log function

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -1338,7 +1338,7 @@ $ sudo systemctl restart docker
       await homey.devkit.stopApp({ session: this._session.session });
       Log.success(`Homey App \`${this._session.appId}\` successfully uninstalled`);
     } catch (err) {
-      Log(err.message || err.toString());
+      Log(err);
     }
 
     process.exit();

--- a/lib/Log.js
+++ b/lib/Log.js
@@ -6,7 +6,7 @@ const colors = require('colors');
 module.exports = (...props) => {
   // Replace every prop's symbols to platform-specific symbols
   for (const [key, value] of Object.entries(props)) {
-    props[key] = figures(value);
+    props[key] = figures(value instanceof Error ? (value.message || value.toString()) : value);
   }
 
   // eslint-disable-next-line no-console


### PR DESCRIPTION
This ensures that the message from a JS Error is printed instead of `string.replace is not a function`.