### PR TITLE
Support dot-notation for changelog option

### DIFF
--- a/bin/cmds/app/version.js
+++ b/bin/cmds/app/version.js
@@ -14,7 +14,7 @@ exports.builder = yargs => {
     .option('changelog', {
       default: null,
       type: 'string',
-      description: 'What\'s new in this version?',
+      description: 'What\'s new in this version? Use dot-notation for translation. Example: --changelog.en "Add new feature" --changelog.de "Neue Funktionalität"',
     })
     .option('commit', {
       description: 'Create a git commit and tag for the new version',

--- a/lib/App.js
+++ b/lib/App.js
@@ -1071,7 +1071,12 @@ $ sudo systemctl restart docker
     const { version } = manifest;
 
     changelogJson[version] = changelogJson[version] || {};
-    changelogJson[version]['en'] = text;
+    
+    if (typeof text !== "string") {
+      changelogJson[version] = text;
+    } else {
+      changelogJson[version]['en'] = text;
+    }
 
     await fse.writeJson(changelogJsonPath, changelogJson, {
       spaces: 2,
@@ -1096,7 +1101,10 @@ $ sudo systemctl restart docker
       if (hasChangelog) {
         commitFiles.push(path.join(this.path, '.homeychangelog.json'));
 
-        changelog = { en: changelog };
+        if (typeof changelog === "string") {
+          changelog = { en: changelog };   
+        }
+        
       } else {
         // Retrieve from changelog file
         const changelogJsonPath = path.join(this.path, '.homeychangelog.json');


### PR DESCRIPTION
I have added support for dot-notation to be used on the changelog option.
This will allow for translations to be added to changelog from a github action running the homey cli.

Example: 
`homey app version patch --changelog.en "Added feature" --changelog.no "Ny funksjon" --commit`

Will add:
{
"en": "Added feature",
"no": "Ny funksjon"
}

to the .homechangelog.json-file, and no breaking changes because:
`homey app version patch --changelog  "Added feature" --commit`
will still add the string to "en" tag as before.

Commit message will use from "en" tag as before.