### PR TITLE
Write initial .homeychangelog.json

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -3279,6 +3279,12 @@ $ sudo systemctl restart docker
 /.homeybuild/`;
 
     await writeFileAsync(path.join(appPath, '.gitignore'), gitIgnore.toString());
+    await writeFileAsync(path.join(appPath, '.homeychangelog.json'), `{ 
+  "1.0.0": {
+    "en": "Initial release"
+  }
+}`
+    );    
 
     Log.success(`App created in \`${appPath}\``);
     Log(`\n\tLearn more about Homey App development at: ${colors.underline('https://apps.developer.homey.app')}\n`);


### PR DESCRIPTION
Changelog file is not created when running `homey app create`.
It is required when running `homey app validate`.

Added initial file with version 1.0.0 (same as app manifest).