### PR TITLE
Add typescript to dependencies and change npx tsc to tsc

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -98,7 +98,7 @@ class App {
     Log.success('Typescript detected. Compiling...');
 
     try {
-      await exec('npx tsc --outDir .homeybuild/', { cwd: appPath });
+      await exec('tsc --outDir .homeybuild/', { cwd: appPath });
 
       Log.success('Typescript compilation successful');
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "socket.io-client": "^4.7.5",
         "tar-fs": "^2.1.1",
         "tmp-promise": "^3.0.3",
+        "typescript": "^5.6.3",
         "underscore": "^1.13.6",
         "update-notifier": "^5.1.0",
         "yargs": "^17.7.2"
@@ -46,7 +47,7 @@
         "eslint-config-athom": "^2.1.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5711,6 +5712,18 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "socket.io-client": "^4.7.5",
     "tar-fs": "^2.1.1",
     "tmp-promise": "^3.0.3",
+    "typescript": "^5.6.3",
     "underscore": "^1.13.6",
     "update-notifier": "^5.1.0",
     "yargs": "^17.7.2"


### PR DESCRIPTION
Problem occurs using homey-cli in github actions or other environments without typescript installed. 
The cli runs the deprecated tsc package instead of the bundled version in typescript.
See issue in [athombv/github-action-homey-app-validate](https://github.com/athombv/github-action-homey-app-validate/issues/3)

I think this raises the required node version from 16 to 18 ?
Not sure how to test my proposal.