### PR TITLE
Add support to expose ports when running locally with Docker

### DIFF
--- a/bin/cmds/app/run.js
+++ b/bin/cmds/app/run.js
@@ -35,6 +35,11 @@ exports.builder = yargs => {
       default: 'bridge',
       type: 'string',
       description: 'Docker network mode. Must match name from `docker network ls`. Only works when running the app inside Docker.',
+    })
+    .option('ports', {
+      default: [],
+      type: 'array',
+      description: 'Docker exposed ports, i.e. `6113/tcp` or `5683/udp`. Only works when running the app inside docker.',
     });
 };
 exports.handler = async yargs => {
@@ -46,6 +51,7 @@ exports.handler = async yargs => {
       skipBuild: yargs.skipBuild,
       linkModules: yargs.linkModules,
       network: yargs.network,
+      ports: yargs.ports,
     });
   } catch (err) {
     if (err instanceof Error && err.stack) {

--- a/lib/App.js
+++ b/lib/App.js
@@ -149,6 +149,7 @@ class App {
     skipBuild = false,
     linkModules = '',
     network = 'bridge',
+    ports = [],
   } = {}) {
     const homey = await AthomApi.getActiveHomey();
 
@@ -176,6 +177,7 @@ class App {
       skipBuild,
       linkModules,
       network,
+      ports,
     });
   }
 
@@ -220,6 +222,7 @@ class App {
     skipBuild,
     linkModules,
     network,
+    ports,
   }) {
     // Prepare Docker
     const docker = new Docker();
@@ -746,9 +749,37 @@ class App {
       },
     };
 
+    const exposedPorts = [];
+    if (Array.isArray(ports)) {
+      const portRegex = /^\d+$/;
+      const portWithProtocolRegex = /^(\d+)\/(udp|tcp)$/;
+      ports.forEach(port => {
+        let portNumber;
+        let portProtocol;
+        if (portRegex.test(port)) {
+          portNumber = port;
+          portProtocol = 'tcp';
+        } else if (portWithProtocolRegex.test(port)) {
+          const matches = portWithProtocolRegex.exec(port);
+          portNumber = matches[1];
+          portProtocol = matches[2];
+        } else {
+          throw new Error(`The requested port "${port}" is not valid`);
+        }
+
+        const dockerPort = `${portNumber}/${portProtocol}`;
+        createOpts.ExposedPorts[dockerPort] = {};
+        createOpts.HostConfig.PortBindings[dockerPort] = [{
+          HostPort: `${portNumber}`,
+        }];
+        exposedPorts.push(dockerPort);
+      });
+    }
+
     Log.success(`Starting debugger at 0.0.0.0:${inspectPort}...`);
     Log.info(' — Open `about://inspect` in Google Chrome and select the remote target.');
     Log.success(`Starting \`${manifest.id}@${manifest.version}\` in a Docker container...`);
+    exposedPorts.forEach(port => Log.info(` — Exposing Docker port ${port} on local machine...`));
     Log.info(' — Press CTRL+C to quit.');
     Log('─────────────── Logging stdout & stderr ───────────────');
 


### PR DESCRIPTION
Sometimes you need to run a local server to receive updates from devices. For example, Shelly uses this to get updates pushed from devices directly to a CoAP or WS listener on Homey.

When running with docker, these listeners are running inside the docker container and currently not exposed, so impossible to access. This PR add the option to configure the exposed ports by docker, making it accessible on your machine. Depending on your machine you might still need to configure your firewall, and you should make sure that your machine IP is configured on the devices instead of the IP of the Homey.