### PR TITLE
Fix passing semver to homey app version

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -1023,17 +1023,14 @@ $ sudo systemctl restart docker
 
     const prevVersion = manifest.version;
 
-    switch (true) {
-      case semver.valid(version):
-        manifest.version = version;
-        break;
-
-      case ['minor', 'major', 'patch'].includes(version):
-        manifest.version = semver.inc(manifest.version, version);
-        break;
-
-      default:
-        throw new Error('Invalid version. Must be either patch, minor or major.');
+    if (semver.valid(version)) {
+      manifest.version = semver.valid(version);
+    }
+    else if (['minor', 'major', 'patch'].includes(version)) {
+      manifest.version = semver.inc(manifest.version, version);
+    }
+    else {
+      throw new Error('Invalid version. Must be either patch, minor or major.');
     }
 
     await writeFileAsync(path.join(manifestFolder, 'app.json'), JSON.stringify(manifest, false, 2));


### PR DESCRIPTION
There's an issue with the `homey app version` command where it won't accept a semver as per the documentation. The reason being that the `semver.isvalid()` function that is being used returns null or a version instead of a boolean. This PR fixes that.