### PR TITLE
NEW: recursive check in .homeycompose

### DIFF
--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -40,6 +40,7 @@ const Log = require('./Log');
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
 const readdirAsync = util.promisify(fs.readdir);
+const statAsync = util.promisify(fs.stat)
 
 const deepClone = object => JSON.parse(JSON.stringify(object));
 
@@ -667,32 +668,33 @@ class HomeyCompose {
     }
   }
 
-  async _getFiles(filesPath) {
-    try {
-      const files = await readdirAsync(filesPath);
+  async _getFiles(dir) {
+    let results = [];
 
-      return files
-        .filter(file => {
-          return file.indexOf('.') !== 0;
-        })
-        .sort((a, b) => {
-          a = path.basename(a, path.extname(a)).toLowerCase();
-          b = path.basename(b, path.extname(b)).toLowerCase();
-          return a.localeCompare(b);
-        });
-    } catch (err) {
-      return [];
-    }
+    try {
+      const files = await this.safeReaddirSync(dir, { recursive: true});
+      results.push(...files.map(file => path.join(dir, file)));
+    } catch (err) {}
+
+    return results
+      .filter(file => !path.basename(file).startsWith('.')) // Exclude hidden files
+      .sort((a, b) => {
+        const nameA = path.basename(a, path.extname(a)).toLowerCase();
+        const nameB = path.basename(b, path.extname(b)).toLowerCase();
+        return nameA.localeCompare(nameB);
+    });
   }
 
   async _getJsonFiles(filesPath) {
     const result = {};
     const files = await this._getFiles(filesPath);
+
+
     for (let i = 0; i < files.length; i++) {
       const filePath = files[i];
       if (path.extname(filePath) !== '.json') continue;
 
-      const fileJson = await this._getJsonFile(path.join(filesPath, filePath));
+      const fileJson = await this._getJsonFile(filePath);
       const fileId = path.basename(filePath, '.json');
 
       result[fileId] = fileJson;
@@ -711,6 +713,13 @@ class HomeyCompose {
     return fileJson;
   }
 
+  async safeReaddirSync(inputPath, args) {
+    if (!fs.existsSync(inputPath) || !fs.statSync(inputPath).isDirectory()) {
+      return [];
+    }
+
+    return fs.readdirSync(inputPath, args);
+  }
 }
 
 module.exports = HomeyCompose;


### PR DESCRIPTION
This adds the possibility to add subfolders inside all .homeycompose folders.

This is easier for apps with lots of capabilities and flow cards


Purpose: i'm combining 2 eufy apps into 1. This helps keeping the overview of the different drivers and capabilities