### PR TITLE
feat(publish): Add Homey App Store guidelines prompt

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -1399,8 +1399,10 @@ $ sudo systemctl restart docker
       }
 
       if (process.env.HOMEY_HEADLESS !== '1') {
-        Log.info('\nBefore publishing, please review the Homey App Store guidelines:');
-        Log.info('https://apps.developer.homey.app/app-store/guidelines\n');
+        Log('');
+        Log.info('Before publishing, please review the Homey App Store guidelines:');
+        Log.info('https://apps.developer.homey.app/app-store/guidelines');
+        Log('');
         const { hasReadGuidelines } = await inquirer.prompt([
           {
             type: 'confirm',

--- a/lib/App.js
+++ b/lib/App.js
@@ -1398,6 +1398,20 @@ $ sudo systemctl restart docker
         }
       }
 
+      if (process.env.HOMEY_HEADLESS !== '1') {
+        Log.info('\nBefore publishing, please review the Homey App Store guidelines:');
+        Log.info('https://apps.developer.homey.app/app-store/guidelines\n');
+        const { hasReadGuidelines } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'hasReadGuidelines',
+            message: 'I have read the Homey App Store guidelines',
+            default: false,
+          },
+        ]);
+        if (!hasReadGuidelines) return;
+      }
+
       let manifest = App.getManifest({ appPath: this.path });
 
       try {


### PR DESCRIPTION
Show the Homey App Store guidelines URL and a confirmation prompt during
`homey app publish`, before the version bump step. Developers confirm
they have read the guidelines before proceeding.

This should improve submission quality and reduce review turnaround,
since submissions are reviewed against these same guidelines.

Skipped in headless mode (`HOMEY_HEADLESS=1`).