### PR TITLE
Ensure esm flag is also correctly set when running "homey app version"

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -865,11 +865,7 @@ $ sudo systemctl restart docker
     Log.success('Pre-processing app...');
 
     // Build app.json from Homey Compose files
-    if (App.hasHomeyCompose({ appPath: this.path })) {
-      const usesModules = App.usesModules({ appPath: this.path });
-
-      await HomeyCompose.build({ appPath: this.path, usesModules });
-    }
+    await HomeyCompose.buildIfUsed(App, this.path);
 
     // Clear the .homeybuild/ folder
     await fse.remove(this._homeyBuildPath).catch(async (err) => {
@@ -1183,9 +1179,7 @@ $ sudo systemctl restart docker
     await writeFileAsync(path.join(manifestFolder, 'app.json'), JSON.stringify(manifest, false, 2));
 
     // Build app.json from Homey Compose files
-    if (App.hasHomeyCompose({ appPath: this.path })) {
-      await HomeyCompose.build({ appPath: this.path });
-    }
+    await HomeyCompose.buildIfUsed(App, this.path);
 
     Log.success(`Updated app.json version to \`${manifest.version}\``);
 
@@ -1197,9 +1191,7 @@ $ sudo systemctl restart docker
       );
 
       // Build app.json from Homey Compose files
-      if (App.hasHomeyCompose({ appPath: this.path })) {
-        await HomeyCompose.build({ appPath: this.path });
-      }
+      await HomeyCompose.buildIfUsed(App, this.path);
     };
 
     return undo;

--- a/lib/AppPython.js
+++ b/lib/AppPython.js
@@ -46,15 +46,15 @@ class AppPython extends App {
   }
 
   static usesTypeScript({ appPath }) {
-    throw new Error('Method should not be called for Python: "App.usesTypeScript"');
+    return false;
   }
 
   static usesModules({ appPath }) {
-    throw new Error('Method should not be called for Python: "App.usesModules"');
+    return false;
   }
 
   static async transpileToTypescript({ appPath }) {
-    throw new Error('Method should not be called for Python: "App.transpileToTypescript".');
+    return;
   }
 
   async build({ findLinks, dockerSocketPath } = {}) {
@@ -117,7 +117,8 @@ class AppPython extends App {
       HOMEY_APP_RUNNER_DEVMODE: process.env.HOMEY_APP_RUNNER_DEVMODE === '1',
       HOMEY_APP_RUNNER_PATH: process.env.HOMEY_APP_RUNNER_PATH_PYTHON, // e.g. /Users/username/Git/homey-app-runner/src
       HOMEY_APP_RUNNER_CMD: ['bash', 'entrypoint.sh'],
-      HOMEY_APP_RUNNER_ID: process.env.HOMEY_APP_RUNNER_ID_PYTHON || 'ghcr.io/athombv/python-homey-app-runner:latest',
+      HOMEY_APP_RUNNER_ID:
+        process.env.HOMEY_APP_RUNNER_ID_PYTHON || 'ghcr.io/athombv/python-homey-app-runner:latest',
       HOMEY_APP_RUNNER_SDK_PATH: process.env.HOMEY_APP_RUNNER_SDK_PATH_PYTHON, // e.g. /Users/username/Git/python-homey-sdk-v3/dist
     };
   }
@@ -261,9 +262,7 @@ class AppPython extends App {
   } = {}) {
     Log.success('Pre-processing app...');
     // Build app.json from Homey Compose files
-    if (App.hasHomeyCompose({ appPath: this.path })) {
-      await HomeyCompose.build({ appPath: this.path, usesModules: false });
-    }
+    await HomeyCompose.buildIfUsed(AppPython, this.path);
 
     const manifest = App.getManifest({ appPath: this.path });
 

--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -49,8 +49,12 @@ const FLOW_TYPES = ['triggers', 'conditions', 'actions'];
 
 class HomeyCompose {
   // Temporary simpler api
-  static async build({ appPath, usesModules }) {
-    const compose = new HomeyCompose(appPath, usesModules);
+  static async buildIfUsed(app, appPath) {
+    if (!app.hasHomeyCompose({ appPath })) {
+      return;
+    }
+
+    const compose = new HomeyCompose(appPath, app.usesModules({ appPath }));
     await compose.run();
   }
 


### PR DESCRIPTION
When running `homey app version` the earlier set `esm` flag would not be set as the parameter wasn't passed in that code path. I've updated the code to ensure that now the compose class decides what needs to be build.