### PR TITLE
fix: copy venvs when validating Python apps

### DIFF
--- a/bin/cmds/app/validate.mjs
+++ b/bin/cmds/app/validate.mjs
@@ -1,5 +1,6 @@
 import Log from '../../../lib/Log.js';
 import AppFactory from '../../../lib/AppFactory.js';
+import AppPython from '../../../lib/AppPython.js';
 
 export const desc = 'Validate a Homey App';
 export const builder = (yargs) => {
@@ -25,7 +26,7 @@ export const handler = async (yargs) => {
   try {
     const app = AppFactory.getAppInstance(yargs.path);
     await app.preprocess({
-      copyAppProductionDependencies: false,
+      copyAppProductionDependencies: app instanceof AppPython,
       dockerSocketPath: yargs.dockerSocketPath,
       findLinks: yargs.findLinks,
     });


### PR DESCRIPTION
Production dependencies were no longer copied when validating apps in 2af96eeb799055e8780f7e62eb54d1deb0f9bf37
In Python apps the required venvs were therefore no longer present during validation, always causing a failure.
This was fixed by now copying the production dependencies again, only for Python apps.

I double checked other invocations of preprocess, and they should still function correctly.