### PR TITLE
Add Compose locale support for titleShort

### DIFF
--- a/lib/HomeyCompose.js
+++ b/lib/HomeyCompose.js
@@ -706,6 +706,14 @@ class HomeyCompose {
             this._appJson.capabilities[capabilityId].title[appLocaleId] = capability.title;
           }
 
+          // Capability.titleShort
+          if (capability.titleShort) {
+            this._appJson.capabilities[capabilityId].titleShort =
+              this._appJson.capabilities[capabilityId].titleShort ?? {};
+            this._appJson.capabilities[capabilityId].titleShort[appLocaleId] =
+              capability.titleShort;
+          }
+
           // Capability.units
           if (capability.units) {
             this._appJson.capabilities[capabilityId].units =
@@ -744,6 +752,16 @@ class HomeyCompose {
                   appJsonDriver.capabilitiesOptions[capabilityId].title ?? {};
                 appJsonDriver.capabilitiesOptions[capabilityId].title[appLocaleId] =
                   capabilityOptions.title;
+              }
+
+              // Driver.capabilitiesOptions[<capabilityId>].titleShort
+              if (capabilityOptions.titleShort) {
+                appJsonDriver.capabilitiesOptions[capabilityId] =
+                  appJsonDriver.capabilitiesOptions[capabilityId] ?? {};
+                appJsonDriver.capabilitiesOptions[capabilityId].titleShort =
+                  appJsonDriver.capabilitiesOptions[capabilityId].titleShort ?? {};
+                appJsonDriver.capabilitiesOptions[capabilityId].titleShort[appLocaleId] =
+                  capabilityOptions.titleShort;
               }
 
               // Driver.capabilitiesOptions[<capabilityId>].units

--- a/tests/lib/homey-compose.test.mjs
+++ b/tests/lib/homey-compose.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import HomeyCompose from '../../lib/HomeyCompose.js';
+
+const tempDirs = [];
+
+async function writeJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+}
+
+async function createComposeApp() {
+  const appPath = await fs.mkdtemp(path.join(os.tmpdir(), 'homey-compose-'));
+  tempDirs.push(appPath);
+
+  await writeJson(path.join(appPath, 'app.json'), {
+    id: 'com.test.compose',
+    version: '1.0.0',
+    compatibility: '>=13.2.1',
+    sdk: 3,
+    name: { en: 'Compose Test' },
+    description: { en: 'Compose Test' },
+    category: ['tools'],
+  });
+  await fs.mkdir(path.join(appPath, 'locales'));
+
+  return appPath;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+describe('HomeyCompose', () => {
+  it('merges capability titleShort from compose locales', async () => {
+    const appPath = await createComposeApp();
+
+    await writeJson(path.join(appPath, '.homeycompose', 'capabilities', 'alarm_test.json'), {
+      type: 'boolean',
+      title: { en: 'Alarm Test' },
+      titleShort: { en: 'Alarm' },
+      getable: true,
+    });
+    await writeJson(path.join(appPath, 'drivers', 'test', 'driver.compose.json'), {
+      name: { en: 'Test Driver' },
+      class: 'socket',
+      capabilities: ['alarm_test'],
+      capabilitiesOptions: {
+        alarm_test: {
+          title: { en: 'Driver Alarm Test' },
+          titleShort: { en: 'Driver Alarm' },
+        },
+      },
+    });
+    await writeJson(path.join(appPath, '.homeycompose', 'locales', 'nl.json'), {
+      $capabilities: {
+        alarm_test: {
+          title: 'Alarm Test NL',
+          titleShort: 'Alarm NL',
+        },
+      },
+      $drivers: {
+        test: {
+          capabilitiesOptions: {
+            alarm_test: {
+              title: 'Driver Alarm Test NL',
+              titleShort: 'Driver Alarm NL',
+            },
+          },
+        },
+      },
+    });
+
+    await HomeyCompose.build({ appPath, usesModules: false });
+
+    const appJson = JSON.parse(await fs.readFile(path.join(appPath, 'app.json'), 'utf8'));
+
+    assert.deepStrictEqual(appJson.capabilities.alarm_test.title, {
+      en: 'Alarm Test',
+      nl: 'Alarm Test NL',
+    });
+    assert.deepStrictEqual(appJson.capabilities.alarm_test.titleShort, {
+      en: 'Alarm',
+      nl: 'Alarm NL',
+    });
+    assert.deepStrictEqual(appJson.drivers[0].capabilitiesOptions.alarm_test.title, {
+      en: 'Driver Alarm Test',
+      nl: 'Driver Alarm Test NL',
+    });
+    assert.deepStrictEqual(appJson.drivers[0].capabilitiesOptions.alarm_test.titleShort, {
+      en: 'Driver Alarm',
+      nl: 'Driver Alarm NL',
+    });
+  });
+});


### PR DESCRIPTION
Adds Homey Compose support for localizing capability `titleShort` fields so they are merged into generated `app.json` the same way capability `title` is.

Summary:
- Merge `$capabilities.<capabilityId>.titleShort` from `.homeycompose/locales/*.json` into `app.json`.
- Merge `$drivers.<driverId>.capabilitiesOptions.<capabilityId>.titleShort` locale overrides.
- Add a focused HomeyCompose regression test using `compatibility: >=13.2.1`.

Related:
- Requires athombv/node-homey-lib#701 for validation that `titleShort` is only used with Homey `>=13.2.1`.

Validation:
- `node --test tests/lib/homey-compose.test.mjs`
- `npx eslint lib/HomeyCompose.js tests/lib/homey-compose.test.mjs --max-warnings=0`
- `node /home/jeroen/workspaces/node-homey/bin/homey.mjs app validate --level debug --path /home/jeroen/workspaces/nl.jwienk.test`