### PR TITLE
Updates platform feature selection for non-local platforms

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -542,7 +542,10 @@ class App {
             homeyVersion: homey.version,
             homeyPlatform: homey.platform,
             homeyPlatformVersion: homey.platformVersion,
-            homeyPlatformFeatures: HomeyLibUtil.getPlatformLocalFeatures(homey.model),
+            homeyPlatformFeatures:
+              homey.platform === 'local'
+                ? HomeyLibUtil.getPlatformLocalFeatures(homey.model)
+                : ['camera-streaming', 'ble-advertisements'],
             homeyLanguage: homey.language,
           },
           (err) => {


### PR DESCRIPTION
Ensures feature list defaults to camera streaming and BLE advertisements when running on non-local platforms, improving compatibility and clarity of reported capabilities. Prevents reliance on unavailable local feature detection outside local environments.