### PR TITLE
feat: Bump node package version on publish

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -1149,7 +1149,7 @@ $ sudo systemctl restart docker
     await fse.copy(homeyModulePath, path.join(this._homeyBuildPath, 'node_modules', 'homey'));
   }
 
-  async version(version) {
+  async version(version, shouldBumpPackageVersion) {
     let manifest;
     let manifestFolder;
 
@@ -1186,7 +1186,7 @@ $ sudo systemctl restart docker
 
     Log.success(`Updated app.json version to \`${manifest.version}\``);
 
-    const undo = async () => {
+    let undo = async () => {
       manifest.version = prevVersion;
       await writeFileAsync(
         path.join(manifestFolder, 'app.json'),
@@ -1197,7 +1197,40 @@ $ sudo systemctl restart docker
       await HomeyCompose.buildIfUsed(App, this.path);
     };
 
-    return undo;
+    if (!shouldBumpPackageVersion) {
+      return undo;
+    }
+
+    const packageJsonPath = path.join(this.path, 'package.json');
+    let packageJson;
+
+    try {
+      packageJson = await fse.readJson(packageJsonPath);
+    } catch (error) {
+      Log.error('Package version bump not possible. Missing package.json file');
+
+      return undo;
+    }
+
+    const prevPackageVersion = packageJson.version;
+
+    await exec(`npm version ${manifest.version} --no-git-tag-version`);
+
+    // Build app.json from Homey Compose files
+    await HomeyCompose.buildIfUsed(App, this.path);
+
+    Log.success(`Updated package version to \`${manifest.version}\``);
+
+    return async () => {
+      // undo app.json version bump
+      await undo();
+
+      // undo package version bump
+      await exec(`npm version ${prevPackageVersion} --no-git-tag-version`);
+
+      // Build app.json from Homey Compose files
+      await HomeyCompose.buildIfUsed(App, this.path);
+    };
   }
 
   async changelog(text) {
@@ -1473,13 +1506,34 @@ $ sudo systemctl restart docker
       let bumpedVersion = false;
       const commitFiles = [];
       if (shouldUpdateVersion.value) {
+        // Ask if package version should be bumped
+        const { shouldBumpPackageVersion } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'shouldBumpPackageVersion',
+            message: `Do you want to update your package version as well? (v${appVersion} -> v${versionBumpChoices[shouldUpdateVersionTo.version].targetVersion})`,
+            default: false,
+          },
+        ]);
+
         // Apply new version (this changes app.json and .homeycompose/app.json if needed)
-        undos.version = await this.version(shouldUpdateVersionTo.version);
+        undos.version = await this.version(shouldUpdateVersionTo.version, shouldBumpPackageVersion);
 
         // Check if only app.json or also .homeycompose/app.json needs to be committed
         commitFiles.push(path.join(this.path, 'app.json'));
         if (await fse.exists(path.join(this._homeyComposePath, 'app.json'))) {
           commitFiles.push(path.join(this._homeyComposePath, 'app.json'));
+        }
+
+        // Check if package.json and package-lock.json needs to be committed IF chosen to be bumped
+        if (shouldBumpPackageVersion) {
+          if (await fse.exists(path.join(this.path, 'package.json'))) {
+            commitFiles.push(path.join(this.path, 'package.json'));
+          }
+
+          if (await fse.exists(path.join(this.path, 'package-lock.json'))) {
+            commitFiles.push(path.join(this.path, 'package-lock.json'));
+          }
         }
 
         // Update version number


### PR DESCRIPTION
Bump **version** in `package.json` and `package-lock.json` as well on publish