### PR TITLE
Bump get-port to 7.2.0

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -23,7 +23,6 @@ const ignoreWalk = require('ignore-walk');
 const fse = require('fs-extra');
 const filesize = require('filesize');
 const querystring = require('querystring');
-const getPort = require('get-port');
 const SocketIOServer = require('socket.io');
 const SocketIOClient = require('socket.io-client');
 const express = require('express');
@@ -290,6 +289,9 @@ class App {
     // Prepare Docker
     const docker = await DockerHelper.ensureDocker({ dockerSocketPath });
 
+    // Import get-port ESM
+    const getPort = await import('get-port');
+
     // Build the App
     await this.buildForLocalRunner(skipBuild, { dockerSocketPath, findLinks });
 
@@ -317,8 +319,8 @@ class App {
     const socketUrl = `${baseUrl}/devkit`;
 
     // Find Inspect Port
-    const inspectPort = await getPort({
-      port: getPort.makeRange(9229, 9229 + 100),
+    const inspectPort = await getPort.default({
+      port: getPort.portNumbers(9229, 9229 + 100),
     });
 
     // Get Environment Variables
@@ -379,8 +381,8 @@ class App {
         });
     });
 
-    const serverPort = await getPort({
-      port: getPort.makeRange(30000, 40000),
+    const serverPort = await getPort.default({
+      port: getPort.portNumbers(30000, 40000),
     });
 
     const serverApp = express();

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "figures": "^3.2.0",
         "filesize": "^6.4.0",
         "fs-extra": "^10.1.0",
-        "get-port": "^5.1.1",
+        "get-port": "^7.2.0",
         "homey-api": "^3.17.7",
         "homey-lib": "^2.51.4",
         "ignore-walk": "^3.0.3",
@@ -2903,11 +2903,12 @@
       }
     },
     "node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "figures": "^3.2.0",
     "filesize": "^6.4.0",
     "fs-extra": "^10.1.0",
-    "get-port": "^5.1.1",
+    "get-port": "^7.2.0",
     "homey-api": "^3.17.7",
     "homey-lib": "^2.51.4",
     "ignore-walk": "^3.0.3",


### PR DESCRIPTION
get-port 6 includes a reliability fix which improves its ability to detect ports. However, the library migrated to ESM only with that same release. As this project still uses CommonJS, the import was replaced with a compatible async import within the only method that uses the get-port library.