### PR TITLE
fix: point uv at the directory --find-links is mounted on

### DIFF
--- a/lib/AppPython.js
+++ b/lib/AppPython.js
@@ -923,7 +923,7 @@ class AppPython extends App {
 
         if (findLinks !== undefined) {
           containerBinds.push(`${findLinks}:/find_links:ro`);
-          dockerCommand.push('--find-links', '/find-links');
+          dockerCommand.push('--find-links', '/find_links');
         }
 
         const createOptions = {


### PR DESCRIPTION
The find-links directory is bind-mounted into the dependency container at /find_links, but uv is invoked with --find-links /find-links. The paths differ by one character, so uv always fails with:

  error: Failed to read `--find-links` directory: /find-links
    Caused by: No such file or directory (os error 2)

This makes the documented --find-links flag unusable on every command that accepts it (app build, dependencies add/remove, run, validate, publish), which is the supported way to develop a Homey app against a locally built Python package rather than a published one.

Use the mount path, matching the neighbouring /.venv and /uv_cache binds.