### PR TITLE
Fix/clean install issues

### DIFF
--- a/assets/templates/app/app.ts
+++ b/assets/templates/app/app.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Homey from 'homey';
 
 export default class MyApp extends Homey.App {

--- a/assets/templates/app/app.ts
+++ b/assets/templates/app/app.ts
@@ -2,7 +2,7 @@
 
 import Homey from 'homey';
 
-module.exports = class MyApp extends Homey.App {
+export default class MyApp extends Homey.App {
 
   /**
    * onInit is called when the app is initialized.

--- a/assets/templates/app/drivers/device.ts
+++ b/assets/templates/app/drivers/device.ts
@@ -1,18 +1,21 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+// All methods are awaited, but some of the types are outdated.
+
 import Homey from 'homey';
 
-module.exports = class MyDevice extends Homey.Device {
+export default class MyDevice extends Homey.Device {
 
   /**
    * onInit is called when the device is initialized.
    */
-  async onInit() {
+  public override async onInit() {
     this.log('MyDevice has been initialized');
   }
 
   /**
    * onAdded is called when the user adds the device, called just after pairing.
    */
-  async onAdded() {
+  public override async onAdded() {
     this.log('MyDevice has been added');
   }
 
@@ -24,7 +27,7 @@ module.exports = class MyDevice extends Homey.Device {
    * @param {string[]} event.changedKeys An array of keys changed since the previous version
    * @returns {Promise<string|void>} return a custom message that will be displayed
    */
-  async onSettings({
+  public override async onSettings({
     oldSettings,
     newSettings,
     changedKeys,
@@ -33,7 +36,7 @@ module.exports = class MyDevice extends Homey.Device {
     newSettings: { [key: string]: boolean | string | number | undefined | null };
     changedKeys: string[];
   }): Promise<string | void> {
-    this.log("MyDevice settings where changed");
+    this.log('MyDevice settings where changed');
   }
 
   /**
@@ -41,15 +44,15 @@ module.exports = class MyDevice extends Homey.Device {
    * This method can be used this to synchronise the name to the device.
    * @param {string} name The new name
    */
-  async onRenamed(name: string) {
+  public override async onRenamed(name: string) {
     this.log('MyDevice was renamed');
   }
 
   /**
    * onDeleted is called when the user deleted the device.
    */
-  async onDeleted() {
+  public override async onDeleted() {
     this.log('MyDevice has been deleted');
   }
 
-};
+}

--- a/assets/templates/app/drivers/device.ts
+++ b/assets/templates/app/drivers/device.ts
@@ -36,7 +36,7 @@ export default class MyDevice extends Homey.Device {
     newSettings: { [key: string]: boolean | string | number | undefined | null };
     changedKeys: string[];
   }): Promise<string | void> {
-    this.log('MyDevice settings where changed');
+    this.log('MyDevice settings were changed');
   }
 
   /**

--- a/assets/templates/app/drivers/driver.mjs
+++ b/assets/templates/app/drivers/driver.mjs
@@ -29,4 +29,4 @@ export default class MyDriver extends Homey.Driver {
     ];
   }
 
-};
+}

--- a/assets/templates/app/drivers/driver.ts
+++ b/assets/templates/app/drivers/driver.ts
@@ -1,11 +1,11 @@
 import Homey from 'homey';
 
-module.exports = class MyDriver extends Homey.Driver {
+export default class MyDriver extends Homey.Driver {
 
   /**
    * onInit is called when the driver is initialized.
    */
-  async onInit() {
+  public override async onInit() {
     this.log('MyDriver has been initialized');
   }
 
@@ -13,7 +13,7 @@ module.exports = class MyDriver extends Homey.Driver {
    * onPairListDevices is called when a user is adding a device and the 'list_devices' view is called.
    * This should return an array with the data of devices that are available for pairing.
    */
-  async onPairListDevices() {
+  public override async onPairListDevices() {
     return [
       // Example device data, note that `store` is optional
       // {
@@ -28,4 +28,4 @@ module.exports = class MyDriver extends Homey.Driver {
     ];
   }
 
-};
+}

--- a/assets/templates/app/widgets/api.mjs
+++ b/assets/templates/app/widgets/api.mjs
@@ -23,4 +23,4 @@ export default {
   async deleteSomething({ homey, params }) {
     return homey.app.deleteSomething(params.id);
   },
-}
+};

--- a/assets/templates/app/widgets/api.mjs
+++ b/assets/templates/app/widgets/api.mjs
@@ -1,0 +1,26 @@
+export default {
+  async getSomething({ homey, query }) {
+    // you can access query parameters like "/?foo=bar" through `query.foo`
+
+    // you can access the App instance through homey.app
+    // const result = await homey.app.getSomething();
+    // return result;
+
+    // perform other logic like mapping result data
+
+    return 'Hello from App';
+  },
+
+  async addSomething({ homey, body }) {
+    // access the post body and perform some action on it.
+    return homey.app.addSomething(body);
+  },
+
+  async updateSomething({ homey, params, body }) {
+    return homey.app.setSomething(body);
+  },
+
+  async deleteSomething({ homey, params }) {
+    return homey.app.deleteSomething(params.id);
+  },
+}

--- a/assets/templates/app/widgets/api.ts
+++ b/assets/templates/app/widgets/api.ts
@@ -1,0 +1,43 @@
+import type { Driver } from 'homey';
+
+type Homey = Driver['homey'];
+
+export default {
+  async getSomething({ homey, query }: {
+    homey: Homey,
+    query: Record<string, string>,
+  }): Promise<string> {
+    // you can access query parameters like "/?foo=bar" through `query.foo`
+
+    // you can access the App instance through homey.app
+    // const result = await homey.app.getSomething();
+    // return result;
+
+    // perform other logic like mapping result data
+
+    return 'Hello from App';
+  },
+
+  async addSomething({ homey, body }: {
+    homey: Homey,
+    body: Record<string, unknown>,
+  }): Promise<void> {
+    // access the post body and perform some action on it.
+    return homey.app.addSomething(body);
+  },
+
+  async updateSomething({ homey, params, body }: {
+    homey: Homey,
+    params: Record<string, string>,
+    body: Record<string, unknown>,
+  }): Promise<void> {
+    return homey.app.setSomething(body);
+  },
+
+  async deleteSomething({ homey, params }: {
+    homey: Homey,
+    params: Record<string, string>,
+  }): Promise<void> {
+    return homey.app.deleteSomething(params.id);
+  },
+};

--- a/lib/App.js
+++ b/lib/App.js
@@ -3568,6 +3568,7 @@ $ sudo systemctl restart docker
     if (answers.typescript) {
       delete packageJson.main;
       packageJson.scripts.build = 'tsc';
+      packageJson.type = 'module';
     }
 
     await writeFileAsync(path.join(appPath, 'package.json'), JSON.stringify(packageJson, false, 2));

--- a/lib/App.js
+++ b/lib/App.js
@@ -3627,7 +3627,7 @@ $ sudo systemctl restart docker
     }
 
     if (answers.eslint) {
-      await NpmCommands.installDev(['eslint@~8.57.1', 'eslint-config-athom'], { appPath });
+      await NpmCommands.installDev(['eslint@~8.57.1', 'eslint-config-athom@~4.0.1'], { appPath });
 
       const eslintConfig = {
         extends: 'athom/homey-app',

--- a/lib/App.js
+++ b/lib/App.js
@@ -3612,11 +3612,22 @@ $ sudo systemctl restart docker
     await HomeyCompose.createComposeDirectories({ appPath });
 
     if (answers.typescript) {
-      await NpmCommands.installDev(['typescript'], { appPath });
+      // Our ESLint version doesn't have support for TypeScript 7. We can't update our eslint version because
+      // our eslint-config doesn't support it yet, and that depends on eslint-config-airbnb, which is waiting for all
+      // of it's dependencies to update before they do. As a workaround, we can install TypeScript 6 for ESLint,
+      // and use @typescript/native to install the lastest TypeScript version for running `tsc`.
+      if (answers.eslint) {
+        await NpmCommands.installDev(
+          ['typescript@npm:@typescript/typescript6', '@typescript/native@npm:typescript'],
+          { appPath },
+        );
+      } else {
+        await NpmCommands.installDev(['typescript'], { appPath });
+      }
     }
 
     if (answers.eslint) {
-      await NpmCommands.installDev(['eslint@^7.32.0', 'eslint-config-athom'], { appPath });
+      await NpmCommands.installDev(['eslint@~8.57.1', 'eslint-config-athom'], { appPath });
 
       const eslintConfig = {
         extends: 'athom/homey-app',

--- a/lib/App.js
+++ b/lib/App.js
@@ -3612,10 +3612,9 @@ $ sudo systemctl restart docker
     await HomeyCompose.createComposeDirectories({ appPath });
 
     if (answers.typescript) {
-      // Our ESLint version doesn't have support for TypeScript 7. We can't update our eslint version because
-      // our eslint-config doesn't support it yet, and that depends on eslint-config-airbnb, which is waiting for all
-      // of it's dependencies to update before they do. As a workaround, we can install TypeScript 6 for ESLint,
-      // and use @typescript/native to install the lastest TypeScript version for running `tsc`.
+      // eslint-config-athom currently relies on tooling that isn't compatible with TypeScript 7 yet.
+      // As a workaround, install TypeScript 6 under the `typescript` package name for ESLint,
+      // and also install the latest TypeScript under an alias for running `tsc`.
       if (answers.eslint) {
         await NpmCommands.installDev(
           ['typescript@npm:@typescript/typescript6', '@typescript/native@npm:typescript'],

--- a/lib/App.js
+++ b/lib/App.js
@@ -2195,26 +2195,16 @@ $ sudo systemctl restart docker
   }
 
   async copyDriverAndDeviceTemplate(templatePath, driverPath) {
-    if (App.usesModules({ appPath: this.path })) {
-      await copyFileAsync(
-        path.join(templatePath, 'driver.mjs'),
-        path.join(driverPath, 'driver.js'),
-      );
-      await copyFileAsync(
-        path.join(templatePath, 'device.mjs'),
-        path.join(driverPath, 'device.js'),
-      );
-    } else {
-      const fileExtension = App.usesTypeScript({ appPath: this.path }) ? '.ts' : '.js';
-      await copyFileAsync(
-        path.join(templatePath, `driver${fileExtension}`),
-        path.join(driverPath, `driver${fileExtension}`),
-      );
-      await copyFileAsync(
-        path.join(templatePath, `device${fileExtension}`),
-        path.join(driverPath, `device${fileExtension}`),
-      );
-    }
+    const { templateExtension, targetExtension } = this.getAppExtensions();
+
+    await copyFileAsync(
+      path.join(templatePath, `driver${templateExtension}`),
+      path.join(driverPath, `driver${targetExtension}`),
+    );
+    await copyFileAsync(
+      path.join(templatePath, `device${templateExtension}`),
+      path.join(driverPath, `device${targetExtension}`),
+    );
   }
 
   async questionDriverWireless() {
@@ -3274,6 +3264,7 @@ $ sudo systemctl restart docker
       JSON.stringify(widgetJson, false, 2),
     );
 
+    const { templateExtension, targetExtension } = this.getAppExtensions();
     const templatePath = path.join(__dirname, '..', 'assets', 'templates', 'app', 'widgets');
     await fse.ensureDir(path.join(widgetPath, 'public'));
     await copyFileAsync(
@@ -3284,7 +3275,10 @@ $ sudo systemctl restart docker
       path.join(templatePath, 'public/homey-logo.png'),
       path.join(widgetPath, 'public/homey-logo.png'),
     );
-    await copyFileAsync(path.join(templatePath, 'api.js'), path.join(widgetPath, 'api.js'));
+    await copyFileAsync(
+      path.join(templatePath, `api${templateExtension}`),
+      path.join(widgetPath, `api${targetExtension}`),
+    );
     await copyFileAsync(
       path.join(templatePath, 'preview-dark.png'),
       path.join(widgetPath, 'preview-dark.png'),
@@ -4051,6 +4045,14 @@ ${readme}`,
   async listDependencies() {
     const result = await exec('npm list');
     Log(result.stdout);
+  }
+
+  getAppExtensions() {
+    if (App.usesTypeScript({ appPath: this.path }))
+      return { templateExtension: '.ts', targetExtension: '.ts' };
+    if (App.usesModules({ appPath: this.path }))
+      return { templateExtension: '.mjs', targetExtension: '.js' };
+    return { templateExtension: '.js', targetExtension: '.js' };
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homey",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homey",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homey",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Command-line interface and type declarations for Homey Apps",
   "main": "bin/homey.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "lint-staged": {
     "**/*.{js,mjs}": [
-      "eslint --max-warnings=0 --fix"
+      "eslint --max-warnings=0 --no-warn-ignored --fix"
     ],
     "**/*.{js,mjs,json,md,yml,yaml,html}": [
       "prettier --write"


### PR DESCRIPTION
TypeScript 7 shipped with a new API, breaking tools like ESLint. To prevent this, TypeScript 6 and 7 are installed in tandem. Tools wil use the tsc6 executable instead, so they run with TypeScript v6. Running `npx tsc` will use TypeScript 7 to benefit from it's increased performance.

For the `device.ts` template the linter rule `no-misused-promises` was disabled, since the return types on some of the methods are wrong. They are all awaited in the SDK. Keeping the right types in the template has priority over a linter rule. Once the types are updated and correct, this linter rule should be enabled again.

Also updated the TypeScript app and driver templates to use `export default` instead of `module.exports` to prevent linter errors. 