### PR TITLE
chore: professionalize release workflow

### DIFF
--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -1,15 +1,5 @@
 name: Update Package Version
 
-# Version: 1.0.0
-# Modified: No
-# Requirements:
-# - A valid package.json
-# - The `Homey Github Actions Bot` should have `Admin` level access to the repository,
-#   to bypass push restrictions.
-#
-# Required secrets:
-# - HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN
-
 on:
   workflow_dispatch:
     inputs:
@@ -23,26 +13,170 @@ on:
           - minor
           - patch
 
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: npm-version-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  publish:
-    name: Publish
+  version:
+    name: Version ${{ inputs.newversion }} on ${{ github.ref_name }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
+
     steps:
-      - name: Checkout git repository
-        uses: actions/checkout@v3
+      - name: Checkout selected branch
+        uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           token: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
-      - name: Set up node environment
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: npm
           registry-url: 'https://npm.pkg.github.com'
 
-      - name: Version
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --audit=false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Determine target version
+        id: version
+        env:
+          BUMP_TYPE: ${{ inputs.newversion }}
         run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_REF_TYPE" != "branch" ]; then
+            echo "::error::Select a branch when dispatching this workflow."
+            exit 1
+          fi
+
+          CURRENT_VERSION="$(node -p "require('./package.json').version")"
+          NEXT_VERSION="$(node -e "const semver = require('semver'); const next = semver.inc(process.argv[1], process.argv[2]); if (next === null) process.exit(1); process.stdout.write(next);" "$CURRENT_VERSION" "$BUMP_TYPE")"
+
+          {
+            echo "current=$CURRENT_VERSION"
+            echo "next=$NEXT_VERSION"
+            echo "tag=v$NEXT_VERSION"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate target version
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin --force --tags
+
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            echo "::error::Git tag $RELEASE_TAG already exists."
+            exit 1
+          fi
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+
+          if npm view "$PACKAGE_NAME@$NEXT_VERSION" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "::error::$PACKAGE_NAME@$NEXT_VERSION is already published to npm."
+            exit 1
+          fi
+
+      - name: Validate stable release state
+        if: github.ref_name == 'develop'
+        env:
+          CURRENT_TAG: v${{ steps.version.outputs.current }}
+        run: |
+          set -euo pipefail
+
+          CURRENT_RELEASE_JSON="$(gh release view "$CURRENT_TAG" --json isDraft,isPrerelease,publishedAt 2>/dev/null || true)"
+
+          if [ -z "$CURRENT_RELEASE_JSON" ]; then
+            echo "::error::The current develop version $CURRENT_TAG does not have a published GitHub Release."
+            exit 1
+          fi
+
+          CURRENT_RELEASE_IS_DRAFT="$(jq -r '.isDraft' <<< "$CURRENT_RELEASE_JSON")"
+          CURRENT_RELEASE_IS_PRERELEASE="$(jq -r '.isPrerelease' <<< "$CURRENT_RELEASE_JSON")"
+          CURRENT_RELEASE_PUBLISHED_AT="$(jq -r '.publishedAt // empty' <<< "$CURRENT_RELEASE_JSON")"
+
+          if [ "$CURRENT_RELEASE_IS_DRAFT" = "true" ] || [ "$CURRENT_RELEASE_IS_PRERELEASE" = "true" ] || [ -z "$CURRENT_RELEASE_PUBLISHED_AT" ]; then
+            echo "::error::Publish the stable GitHub Release for $CURRENT_TAG before creating another stable version."
+            exit 1
+          fi
+
+          DRAFT_TAGS="$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases" --jq '.[] | select(.draft) | .tag_name')"
+
+          if [ -n "$DRAFT_TAGS" ]; then
+            echo "::error::Publish the existing draft release before creating another stable version."
+            echo "$DRAFT_TAGS"
+            exit 1
+          fi
+
+          OPEN_PROMOTION_PRS="$(gh pr list --state open --base master --head develop --json number --jq 'length')"
+
+          if [ "$OPEN_PROMOTION_PRS" -ne 0 ]; then
+            echo "::error::Merge or close the existing develop to master pull request before creating another stable version."
+            exit 1
+          fi
+
+      - name: Run release checks
+        run: |
+          npm run prettier:check
+          npm run lint
+          npm run test:coverage
+          npm publish --dry-run --registry https://registry.npmjs.org
+
+      - name: Create and push version
+        env:
+          BUMP_TYPE: ${{ inputs.newversion }}
+          EXPECTED_VERSION: ${{ steps.version.outputs.next }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
           git config --local user.email "sysadmin+githubactions@athom.com"
           git config --local user.name "Homey Github Actions Bot"
-          git pull
-          npm version ${{ github.event.inputs.newversion }}
-          git push --follow-tags
+
+          npm version "$BUMP_TYPE" -m "chore(release): v%s"
+
+          ACTUAL_VERSION="$(node -p "require('./package.json').version")"
+
+          if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Expected version $EXPECTED_VERSION, but npm created $ACTUAL_VERSION."
+            exit 1
+          fi
+
+          git push --atomic origin "HEAD:$GITHUB_REF_NAME" "$RELEASE_TAG"
+
+      - name: Create stable draft release
+        if: github.ref_name == 'develop'
+        id: release
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          RELEASE_URL="$(gh release create "$RELEASE_TAG" --draft --generate-notes --title "$RELEASE_TAG" --verify-tag)"
+          echo "url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Open master promotion pull request
+        if: github.ref_name == 'develop'
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_URL: ${{ steps.release.outputs.url }}
+        run: |
+          set -euo pipefail
+
+          gh pr create \
+            --base master \
+            --head develop \
+            --title "Release $RELEASE_TAG" \
+            --body "Promotes $RELEASE_TAG from develop to master. Review and publish the draft GitHub Release before promoting master to production: $RELEASE_URL"

--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -59,6 +59,11 @@ jobs:
             exit 1
           fi
 
+          if [ "$GITHUB_REF_NAME" = "master" ] || [ "$GITHUB_REF_NAME" = "production" ]; then
+            echo "::error::Version bumps cannot run directly on the master or production promotion branches."
+            exit 1
+          fi
+
           CURRENT_VERSION="$(node -p "require('./package.json').version")"
           NEXT_VERSION="$(node -e "const semver = require('semver'); const next = semver.inc(process.argv[1], process.argv[2]); if (next === null) process.exit(1); process.stdout.write(next);" "$CURRENT_VERSION" "$BUMP_TYPE")"
 
@@ -92,9 +97,15 @@ jobs:
       - name: Validate stable release state
         if: github.ref_name == 'develop'
         env:
+          CURRENT_VERSION: ${{ steps.version.outputs.current }}
           CURRENT_TAG: v${{ steps.version.outputs.current }}
         run: |
           set -euo pipefail
+
+          git fetch origin \
+            "+refs/heads/production:refs/remotes/origin/production" \
+            --force \
+            --tags
 
           CURRENT_RELEASE_JSON="$(gh release view "$CURRENT_TAG" --json isDraft,isPrerelease,publishedAt 2>/dev/null || true)"
 
@@ -124,6 +135,33 @@ jobs:
 
           if [ "$OPEN_PROMOTION_PRS" -ne 0 ]; then
             echo "::error::Merge or close the existing develop to master pull request before creating another stable version."
+            exit 1
+          fi
+
+          OPEN_PRODUCTION_PRS="$(gh pr list --state open --base production --head master --json number --jq 'length')"
+
+          if [ "$OPEN_PRODUCTION_PRS" -ne 0 ]; then
+            echo "::error::Merge or close the existing master to production pull request before creating another stable version."
+            exit 1
+          fi
+
+          PRODUCTION_VERSION="$(git show origin/production:package.json | node -e "let json = ''; process.stdin.on('data', chunk => { json += chunk; }); process.stdin.on('end', () => { process.stdout.write(JSON.parse(json).version); });")"
+
+          if [ "$PRODUCTION_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "::error::Production is on $PRODUCTION_VERSION; release $CURRENT_TAG before creating another stable version."
+            exit 1
+          fi
+
+          if ! git diff --quiet "$CURRENT_TAG^{tree}" "origin/production^{tree}"; then
+            echo "::error::Production contents do not match the released $CURRENT_TAG contents."
+            exit 1
+          fi
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          LATEST_NPM_VERSION="$(npm view "$PACKAGE_NAME" dist-tags.latest --registry https://registry.npmjs.org 2>/dev/null || true)"
+
+          if [ "$LATEST_NPM_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "::error::npm latest is $LATEST_NPM_VERSION; publish $PACKAGE_NAME@$CURRENT_VERSION before creating another stable version."
             exit 1
           fi
 

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -72,14 +72,16 @@ jobs:
             exit 0
           fi
 
-          if ! git merge-base --is-ancestor "$RELEASE_TAG^{commit}" origin/master; then
-            echo "Tag $RELEASE_TAG is not contained in master yet." >> "$GITHUB_STEP_SUMMARY"
+          if ! git diff --quiet "$RELEASE_TAG^{tree}" "origin/master^{tree}"; then
+            echo "Master contents do not match the tagged $RELEASE_TAG contents yet." >> "$GITHUB_STEP_SUMMARY"
             echo "ready=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if git merge-base --is-ancestor "$RELEASE_TAG^{commit}" origin/production; then
-            echo "$RELEASE_TAG is already contained in production." >> "$GITHUB_STEP_SUMMARY"
+          PRODUCTION_VERSION="$(git show origin/production:package.json | node -e "let json = ''; process.stdin.on('data', chunk => { json += chunk; }); process.stdin.on('end', () => { process.stdout.write(JSON.parse(json).version); });")"
+
+          if [ "$PRODUCTION_VERSION" = "$VERSION" ]; then
+            echo "$RELEASE_TAG is already the production version." >> "$GITHUB_STEP_SUMMARY"
             echo "ready=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,110 @@
+name: Promote Published Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: promote-published-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote master to production
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+          token: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Check promotion readiness
+        id: readiness
+        run: |
+          set -euo pipefail
+
+          git fetch origin \
+            "+refs/heads/master:refs/remotes/origin/master" \
+            "+refs/heads/production:refs/remotes/origin/production" \
+            --force \
+            --tags
+
+          VERSION="$(node -p "require('./package.json').version")"
+          RELEASE_TAG="v$VERSION"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+          RELEASE_JSON="$(gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,publishedAt,url 2>/dev/null || true)"
+
+          if [ -z "$RELEASE_JSON" ]; then
+            echo "No GitHub Release exists for $RELEASE_TAG yet." >> "$GITHUB_STEP_SUMMARY"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IS_DRAFT="$(jq -r '.isDraft' <<< "$RELEASE_JSON")"
+          IS_PRERELEASE="$(jq -r '.isPrerelease' <<< "$RELEASE_JSON")"
+          PUBLISHED_AT="$(jq -r '.publishedAt // empty' <<< "$RELEASE_JSON")"
+          RELEASE_URL="$(jq -r '.url' <<< "$RELEASE_JSON")"
+
+          if [ "$IS_DRAFT" = "true" ] || [ "$IS_PRERELEASE" = "true" ] || [ -z "$PUBLISHED_AT" ]; then
+            echo "GitHub Release $RELEASE_TAG is not a published stable release." >> "$GITHUB_STEP_SUMMARY"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git rev-parse --verify "$RELEASE_TAG^{commit}" >/dev/null 2>&1; then
+            echo "Tag $RELEASE_TAG does not exist." >> "$GITHUB_STEP_SUMMARY"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git merge-base --is-ancestor "$RELEASE_TAG^{commit}" origin/master; then
+            echo "Tag $RELEASE_TAG is not contained in master yet." >> "$GITHUB_STEP_SUMMARY"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor "$RELEASE_TAG^{commit}" origin/production; then
+            echo "$RELEASE_TAG is already contained in production." >> "$GITHUB_STEP_SUMMARY"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          OPEN_PRS="$(gh pr list --state open --base production --head master --json number --jq 'length')"
+
+          if [ "$OPEN_PRS" -ne 0 ]; then
+            echo "A master to production pull request is already open." >> "$GITHUB_STEP_SUMMARY"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open production promotion pull request
+        if: steps.readiness.outputs.ready == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.readiness.outputs.tag }}
+          RELEASE_URL: ${{ steps.readiness.outputs.release_url }}
+        run: |
+          set -euo pipefail
+
+          gh pr create \
+            --base production \
+            --head master \
+            --title "Release $RELEASE_TAG to production" \
+            --body "Promotes the published $RELEASE_TAG release from master to production. Merging this pull request publishes the package to npm: $RELEASE_URL"

--- a/.github/workflows/publish-package-npm.yml
+++ b/.github/workflows/publish-package-npm.yml
@@ -1,21 +1,5 @@
 name: Publish to NPM
 
-# Version: 2.1.0
-# Modified: No
-# Requirements:
-# - Ensure you've run `npm version major|minor|patch` on the `master` branch before merging to `production`.
-#
-# This GitHub Workflow:
-# 1. Installs dependencies with `npm ci`.
-# 2. [Optional] If `npm run build` exists, it runs `npm run build`.
-# 3. Publishes the package to the NPM registry.
-#
-# Secrets:
-# - HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN
-# - SLACK_WEBHOOK_URL: required for posting a message in #software
-
-# Note: when publishing a scoped npm package (e.g. @athombv/node-my-package),
-# add "publishConfig": { "access": "public" } to your package.json.
 on:
   workflow_dispatch:
   push:
@@ -24,7 +8,7 @@ on:
       - production
 
 permissions:
-  id-token: write # Required for OIDC
+  id-token: write
   contents: read
 
 jobs:
@@ -34,6 +18,8 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Setup
       - name: Set up node
@@ -44,18 +30,58 @@ jobs:
 
       # Sets package.json name & version to environment.
       - name: Get Package Info
+        id: package
         run: |
           NAME="$(node -p "require('./package.json').name")"
-          echo package_name=${NAME} >> $GITHUB_ENV
+          echo "package_name=$NAME" >> "$GITHUB_ENV"
 
           VERSION="$(node -p "require('./package.json').version")"
-          echo package_version=${VERSION} >> $GITHUB_ENV
+          echo "package_version=$VERSION" >> "$GITHUB_ENV"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      # Ensure `packake.json .files` exists.
-      - name: Verify
+      - name: Verify package configuration
         run: |
-          if ! cat package.json | jq -e .files; then
+          if ! jq --exit-status '.files | type == "array" and length > 0' package.json >/dev/null; then
             echo "Missing 'files' array in package.json."
+            exit 1
+          fi
+
+      - name: Verify published GitHub Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: v${{ steps.package.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          RELEASE_JSON="$(gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,publishedAt,tagName 2>/dev/null)" || {
+            echo "::error::A published GitHub Release for $RELEASE_TAG is required before publishing to npm."
+            exit 1
+          }
+
+          IS_DRAFT="$(jq -r '.isDraft' <<< "$RELEASE_JSON")"
+          IS_PRERELEASE="$(jq -r '.isPrerelease' <<< "$RELEASE_JSON")"
+          PUBLISHED_AT="$(jq -r '.publishedAt // empty' <<< "$RELEASE_JSON")"
+          RELEASE_TAG_NAME="$(jq -r '.tagName' <<< "$RELEASE_JSON")"
+
+          if [ "$IS_DRAFT" = "true" ] || [ "$IS_PRERELEASE" = "true" ] || [ -z "$PUBLISHED_AT" ]; then
+            echo "::error::$RELEASE_TAG must be a published stable GitHub Release."
+            exit 1
+          fi
+
+          if [ "$RELEASE_TAG_NAME" != "$RELEASE_TAG" ]; then
+            echo "::error::Expected release tag $RELEASE_TAG, but found $RELEASE_TAG_NAME."
+            exit 1
+          fi
+
+          if ! git rev-parse --verify "$RELEASE_TAG^{commit}" >/dev/null 2>&1; then
+            echo "::error::Git tag $RELEASE_TAG does not exist."
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$RELEASE_TAG^{commit}" "$GITHUB_SHA"; then
+            echo "::error::Git tag $RELEASE_TAG is not contained in this production revision."
             exit 1
           fi
 
@@ -64,7 +90,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
-      # Run `npm run build` if it exists.
       - name: Build
         run: |
           if jq --exit-status '.scripts | has("build")' package.json; then
@@ -74,7 +99,6 @@ jobs:
             echo "'npm run build' does not exist. Skipping build..."
           fi
 
-      # Configure the publish registry; npm publish will authenticate via OIDC.
       - name: Configure NPM for publish
         run: |
           cat <<EOF > "$NPM_CONFIG_USERCONFIG"
@@ -85,25 +109,48 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: npm publish --dry-run --tag beta --registry https://registry.npmjs.org
 
-      # Publish when this action is running on branch production.
-      - name: Publish
-        if: github.ref == 'refs/heads/production'
+      - name: Check stable package status
+        if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+        id: stable_package
+        env:
+          PACKAGE_NAME: ${{ steps.package.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          PUBLISHED_GIT_HEAD="$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" gitHead --registry https://registry.npmjs.org 2>/dev/null || true)"
+
+          if [ -z "$PUBLISHED_GIT_HEAD" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$PUBLISHED_GIT_HEAD" != "$GITHUB_SHA" ]; then
+            echo "::error::$PACKAGE_NAME@$PACKAGE_VERSION already exists on npm from commit $PUBLISHED_GIT_HEAD."
+            exit 1
+          fi
+
+          echo "publish=false" >> "$GITHUB_OUTPUT"
+          echo "publish_status=Already published" >> "$GITHUB_ENV"
+
+      - name: Publish stable package
+        if: github.event_name == 'push' && github.ref == 'refs/heads/production' && steps.stable_package.outputs.publish == 'true'
         run: |
           npm publish --registry https://registry.npmjs.org
+          echo "publish_status=Published" >> "$GITHUB_ENV"
 
-      # Publish to beta when this action is running on branch testing.
       - name: Publish (beta)
-        if: github.ref == 'refs/heads/testing'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/testing'
         run: |
           npm publish --tag beta --registry https://registry.npmjs.org
+          echo "publish_status=Published beta" >> "$GITHUB_ENV"
 
-        # Post a Slack notification on success/failure
       - name: Slack notify
         if: always() && github.event_name != 'workflow_dispatch'
         uses: innocarpe/actions-slack@v1
         with:
           status: ${{ job.status }}
-          success_text: '${{github.repository}} - Published ${{ env.package_name }}@${{ env.package_version }} to npm 🚀'
+          success_text: '${{ github.repository }} - ${{ env.publish_status }} ${{ env.package_name }}@${{ env.package_version }} to npm 🚀'
           failure_text: '${{github.repository}} - Failed to publish ${{ env.package_name }}@${{ env.package_version }} to npm'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package-npm.yml
+++ b/.github/workflows/publish-package-npm.yml
@@ -80,8 +80,15 @@ jobs:
             exit 1
           fi
 
-          if ! git merge-base --is-ancestor "$RELEASE_TAG^{commit}" "$GITHUB_SHA"; then
-            echo "::error::Git tag $RELEASE_TAG is not contained in this production revision."
+          TAG_VERSION="$(git show "$RELEASE_TAG:package.json" | node -e "let json = ''; process.stdin.on('data', chunk => { json += chunk; }); process.stdin.on('end', () => { process.stdout.write(JSON.parse(json).version); });")"
+
+          if [ "$TAG_VERSION" != "${RELEASE_TAG#v}" ]; then
+            echo "::error::Git tag $RELEASE_TAG contains package version $TAG_VERSION."
+            exit 1
+          fi
+
+          if ! git diff --quiet "$RELEASE_TAG^{tree}" "$GITHUB_SHA^{tree}"; then
+            echo "::error::Production contents do not match the tagged $RELEASE_TAG release contents."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The smoke test pulls `alpine:3.20` when it is not available locally, runs a one-
 container, and removes the container afterward. It is not part of normal tests or CI. Override the
 image with `HOMEY_TEST_DOCKER_IMAGE` or the socket with `HOMEY_TEST_DOCKER_SOCKET` when needed.
 
+## Releasing
+
+Maintainers can find the stable and testing release procedures in [RELEASING.md](RELEASING.md).
+
 ## Shell completion
 
 ### Bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,50 @@
+# Releasing Homey CLI
+
+The version workflow supports stable releases from `develop` and testing releases from any other
+branch. Start it from **Actions → Update Package Version**, select the source branch, and choose a
+major, minor, or patch bump.
+
+## Stable releases
+
+1. Run **Update Package Version** on `develop`.
+2. Review the generated draft GitHub Release and the `develop` to `master` pull request.
+3. Merge the pull request into `master`.
+4. Edit the release notes as needed and publish the GitHub Release. The notes may be empty, but the
+   release must be published.
+5. Publishing the release and merging into `master` jointly cause a `master` to `production` pull
+   request to be opened. Either action may happen first.
+6. Review and merge the production pull request. The production workflow verifies the published
+   release again before publishing the matching version to npm with the `latest` dist-tag.
+
+Only one stable draft may exist. Publish it, and merge or close any existing `develop` to `master`
+promotion pull request, before starting another stable version. The workflow also verifies that the
+current version on `develop` has a published stable GitHub Release, so deleting a draft does not
+bypass this requirement.
+
+## Testing releases
+
+Run **Update Package Version** on the branch that contains the testing changes, then merge or push
+that version to `testing`. A non-`develop` bump creates only the version commit and tag: it does not
+inspect drafts, create a GitHub Release, or open a promotion pull request.
+
+Pushing `testing` publishes the package with the npm `beta` dist-tag. Testing releases currently use
+ordinary semantic versions rather than prerelease versions. npm versions are immutable, so a version
+published as beta cannot later be published again as a stable artifact; use a new version for the
+subsequent stable release.
+
+## Naming
+
+- Version commit: `chore(release): vX.Y.Z`
+- Git tag and GitHub Release: `vX.Y.Z`
+- Stable pull requests: `Release vX.Y.Z` and `Release vX.Y.Z to production`
+
+## Recovering from failures
+
+All validation runs before the version commit is created, and the commit and tag are pushed
+atomically. If GitHub Release creation fails after that push, create the missing draft manually from
+the existing tag; do not run another bump. If pull-request creation fails, keep the draft and create
+the corresponding promotion pull request manually.
+
+The promotion workflow is safe to rerun manually. It opens a pull request only after both the
+published GitHub Release and matching version on `master` exist, and it does nothing if a promotion
+pull request is already open or production already contains the release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,16 @@
 # Releasing Homey CLI
 
-The version workflow supports stable releases from `develop` and testing releases from any other
-branch. Start it from **Actions → Update Package Version**, select the source branch, and choose a
-major, minor, or patch bump.
+The version workflow supports stable releases from `develop` and testing releases from branches
+other than `master` and `production`. Start it from **Actions → Update Package Version**, select the
+source branch, and choose a major, minor, or patch bump. Direct version bumps on the two promotion
+branches are rejected.
 
 ## Stable releases
 
 1. Run **Update Package Version** on `develop`.
 2. Review the generated draft GitHub Release and the `develop` to `master` pull request.
-3. Merge the pull request into `master`.
+3. Merge the pull request into `master`. Merge commits, squash merges, and rebase merges are all
+   supported, provided the resulting repository contents match the tagged release.
 4. Edit the release notes as needed and publish the GitHub Release. The notes may be empty, but the
    release must be published.
 5. Publishing the release and merging into `master` jointly cause a `master` to `production` pull
@@ -16,10 +18,11 @@ major, minor, or patch bump.
 6. Review and merge the production pull request. The production workflow verifies the published
    release again before publishing the matching version to npm with the `latest` dist-tag.
 
-Only one stable draft may exist. Publish it, and merge or close any existing `develop` to `master`
-promotion pull request, before starting another stable version. The workflow also verifies that the
-current version on `develop` has a published stable GitHub Release, so deleting a draft does not
-bypass this requirement.
+Only one stable draft may exist. Publish it and complete both promotion pull requests before
+starting another stable version. The workflow verifies that the current version on `develop` has a
+published stable GitHub Release, matches the contents and version on `production`, and is the npm
+`latest` version. This prevents a later release from entering an older, still-open production pull
+request or bypassing a deleted draft.
 
 ## Testing releases
 
@@ -46,5 +49,5 @@ the existing tag; do not run another bump. If pull-request creation fails, keep 
 the corresponding promotion pull request manually.
 
 The promotion workflow is safe to rerun manually. It opens a pull request only after both the
-published GitHub Release and matching version on `master` exist, and it does nothing if a promotion
-pull request is already open or production already contains the release.
+published GitHub Release and matching tagged contents on `master` exist, and it does nothing if a
+promotion pull request is already open or production already has the release version.


### PR DESCRIPTION
## Summary

- create editable draft GitHub Releases for version bumps performed on develop
- promote published releases through master and production before publishing to npm
- retain branch-selectable version bumps and the independent testing/beta path
- make stable npm publication idempotent and manual workflow runs dry-run-only
- document stable, testing, and recovery procedures

## Validation

- npm run prettier:check
- npm run lint
- npm run test:coverage (235 tests)
- npm publish --dry-run --registry https://registry.npmjs.org
- actionlint and shellcheck for the changed workflows
- release branch-gating assertions and live v4.4.3 consistency checks

## Rollout

- backfilled v4.4.3 as the first published GitHub Release