### PR TITLE
Publish local app runner ports from Docker

### DIFF
--- a/bin/cmds/app/run.mjs
+++ b/bin/cmds/app/run.mjs
@@ -44,6 +44,12 @@ export const builder = (yargs) => {
       default: undefined,
       type: 'string',
       desc: 'Additional location to search for candidate Python package distributions',
+    })
+    .option('docker-exposed-ports', {
+      default: [],
+      type: 'array',
+      description:
+        'Publish container ports on the host, e.g. `--docker-exposed-ports 6113/tcp 5683/udp`. Ports bind to the same port on all host interfaces, so configure your firewall accordingly. Only works when running the app inside Docker.',
     });
 };
 export const handler = async (yargs) => {
@@ -57,6 +63,7 @@ export const handler = async (yargs) => {
       network: yargs.network,
       dockerSocketPath: yargs.dockerSocketPath,
       findLinks: yargs.findLinks,
+      dockerExposedPorts: yargs.dockerExposedPorts,
     });
   } catch (err) {
     if (err instanceof Error && err.stack) {

--- a/lib/App.js
+++ b/lib/App.js
@@ -197,6 +197,7 @@ class App {
     linkModules = '',
     network,
     dockerSocketPath,
+    dockerExposedPorts = [],
   } = {}) {
     const homey = await AthomApi.getActiveHomey();
 
@@ -228,6 +229,7 @@ class App {
       linkModules,
       network,
       dockerSocketPath,
+      dockerExposedPorts,
     });
   }
 
@@ -285,7 +287,18 @@ class App {
     };
   }
 
-  async runDocker({ homey, clean, skipBuild, linkModules, network, dockerSocketPath, findLinks }) {
+  async runDocker({
+    homey,
+    clean,
+    skipBuild,
+    linkModules,
+    network,
+    dockerSocketPath,
+    findLinks,
+    dockerExposedPorts,
+  }) {
+    const dockerPortConfiguration = DockerHelper.createPortConfiguration(dockerExposedPorts);
+
     // Prepare Docker
     const docker = await DockerHelper.ensureDocker({ dockerSocketPath });
 
@@ -676,6 +689,7 @@ class App {
       userdataDir,
       linkModules,
       docker,
+      dockerPortConfiguration,
     );
 
     await cleanup();
@@ -694,6 +708,7 @@ class App {
     userdataDir,
     linkModules,
     docker,
+    dockerPortConfiguration = DockerHelper.createPortConfiguration(),
   ) {
     const {
       HOMEY_APP_RUNNER_DEVMODE,
@@ -762,6 +777,7 @@ class App {
       name: `homey-app-runner-${sessionId}-${manifest.id}-v${manifest.version}`,
       Env: containerEnv,
       ExposedPorts: {
+        ...dockerPortConfiguration.exposedPorts,
         [`${inspectPort}/tcp`]: {},
       },
       Labels: {
@@ -775,6 +791,7 @@ class App {
         ReadonlyRootfs: true,
         NetworkMode: network,
         PortBindings: {
+          ...dockerPortConfiguration.portBindings,
           [`${inspectPort}/tcp`]: [
             {
               HostPort: String(inspectPort),
@@ -788,6 +805,9 @@ class App {
     Log.success(`Starting debugger at 0.0.0.0:${inspectPort}...`);
     Log.info(' — Open `about://inspect` in Google Chrome and select the remote target.');
     Log.success(`Starting \`${manifest.id}@${manifest.version}\` in a Docker container...`);
+    for (const publishedPort of dockerPortConfiguration.publishedPorts) {
+      Log.info(` — Publishing Docker port ${publishedPort} on the local machine...`);
+    }
     Log.info(' — Press CTRL+C to quit.');
     Log('─────────────── Logging stdout & stderr ───────────────');
 

--- a/lib/App.js
+++ b/lib/App.js
@@ -334,6 +334,7 @@ class App {
     // Find Inspect Port
     const inspectPort = await getPort.default({
       port: getPort.portNumbers(9229, 9229 + 100),
+      exclude: dockerPortConfiguration.publishedTcpPorts,
     });
 
     // Get Environment Variables
@@ -396,6 +397,7 @@ class App {
 
     const serverPort = await getPort.default({
       port: getPort.portNumbers(30000, 40000),
+      exclude: dockerPortConfiguration.publishedTcpPorts,
     });
 
     const serverApp = express();

--- a/lib/AppPython.js
+++ b/lib/AppPython.js
@@ -76,6 +76,7 @@ class AppPython extends App {
     network,
     dockerSocketPath,
     findLinks,
+    dockerExposedPorts = [],
   } = {}) {
     const homey = await AthomApi.getActiveHomey();
 
@@ -98,6 +99,7 @@ class AppPython extends App {
       network,
       dockerSocketPath,
       findLinks,
+      dockerExposedPorts,
     });
   }
 
@@ -135,6 +137,7 @@ class AppPython extends App {
     userdataDir,
     linkModules,
     docker,
+    dockerPortConfiguration = DockerHelper.createPortConfiguration(),
   ) {
     const {
       HOMEY_APP_RUNNER_DEVMODE,
@@ -181,6 +184,7 @@ class AppPython extends App {
     const createOpts = {
       name: `homey-app-runner-${sessionId}-${manifest.id}-v${manifest.version}`,
       Env: containerEnv,
+      ExposedPorts: dockerPortConfiguration.exposedPorts,
       Labels: {
         'com.athom.session': sessionId,
         'com.athom.port': String(serverPort),
@@ -190,12 +194,16 @@ class AppPython extends App {
       },
       HostConfig: {
         NetworkMode: network,
+        PortBindings: dockerPortConfiguration.portBindings,
         Binds: containerBinds,
       },
       User: process.getuid !== undefined ? `${process.getuid()}:${process.getgid()}` : undefined,
     };
 
     Log.success(`Starting \`${manifest.id}@${manifest.version}\` in a Docker container...`);
+    for (const publishedPort of dockerPortConfiguration.publishedPorts) {
+      Log.info(` — Publishing Docker port ${publishedPort} on the local machine...`);
+    }
     Log.info(' — Press CTRL+C to quit.');
     Log('─────────────── Logging stdout & stderr ───────────────');
 

--- a/lib/DockerHelper.js
+++ b/lib/DockerHelper.js
@@ -26,6 +26,7 @@ class DockerHelper {
     const exposedPorts = {};
     const portBindings = {};
     const publishedPorts = [];
+    const publishedTcpPorts = [];
 
     for (const portSpecValue of portSpecs) {
       const portSpec = String(portSpecValue);
@@ -52,12 +53,17 @@ class DockerHelper {
       if (!publishedPorts.includes(dockerPort)) {
         publishedPorts.push(dockerPort);
       }
+
+      if (protocol === 'tcp' && !publishedTcpPorts.includes(portNumber)) {
+        publishedTcpPorts.push(portNumber);
+      }
     }
 
     return {
       exposedPorts,
       portBindings,
       publishedPorts,
+      publishedTcpPorts,
     };
   }
 

--- a/lib/DockerHelper.js
+++ b/lib/DockerHelper.js
@@ -18,6 +18,49 @@ const Settings = require('../services/Settings');
 class DockerHelper {
   static #dockerInstanceCache = null;
 
+  static createPortConfiguration(portSpecs = []) {
+    if (!Array.isArray(portSpecs)) {
+      throw new TypeError('Docker exposed ports must be an array');
+    }
+
+    const exposedPorts = {};
+    const portBindings = {};
+    const publishedPorts = [];
+
+    for (const portSpecValue of portSpecs) {
+      const portSpec = String(portSpecValue);
+      const match = /^(\d+)(?:\/(tcp|udp))?$/.exec(portSpec);
+
+      if (match === null) {
+        throw new Error(
+          `Invalid Docker port "${portSpec}". Expected "<port>", "<port>/tcp", or "<port>/udp".`,
+        );
+      }
+
+      const portNumber = Number(match[1]);
+
+      if (portNumber < 1 || portNumber > 65535) {
+        throw new Error(`Invalid Docker port "${portSpec}". Port must be between 1 and 65535.`);
+      }
+
+      const protocol = match[2] ?? 'tcp';
+      const dockerPort = `${portNumber}/${protocol}`;
+
+      exposedPorts[dockerPort] = {};
+      portBindings[dockerPort] = [{ HostPort: String(portNumber) }];
+
+      if (!publishedPorts.includes(dockerPort)) {
+        publishedPorts.push(dockerPort);
+      }
+    }
+
+    return {
+      exposedPorts,
+      portBindings,
+      publishedPorts,
+    };
+  }
+
   /**
    * Ensure there is a Docker instance
    *

--- a/tests/app/run-install.test.mjs
+++ b/tests/app/run-install.test.mjs
@@ -32,6 +32,7 @@ describe('app run characterization', () => {
       network: 'host',
       skipBuild: true,
       dockerSocketPath: '/tmp/docker.sock',
+      dockerExposedPorts: ['6113/tcp', '5683/udp'],
     });
 
     assert.strictEqual(result, 'docker-result');
@@ -43,6 +44,7 @@ describe('app run characterization', () => {
         linkModules: '/tmp/module',
         network: 'host',
         dockerSocketPath: '/tmp/docker.sock',
+        dockerExposedPorts: ['6113/tcp', '5683/udp'],
       },
     ]);
   });
@@ -210,6 +212,35 @@ describe('app install characterization', () => {
 });
 
 describe('Python app run characterization', () => {
+  it('routes published ports to the Python Docker runner', async (t) => {
+    const appPath = await copyFixtureApp(t, 'python-basic');
+    const app = new AppPython(appPath);
+    const { homey } = createFakeHomey();
+    const runCalls = [];
+
+    t.mock.method(AthomApi, 'getActiveHomey', async () => {
+      return homey;
+    });
+    t.mock.method(app, 'runDocker', async (options) => {
+      runCalls.push(options);
+    });
+
+    await app.run({ dockerExposedPorts: ['5683/udp'] });
+
+    assert.deepStrictEqual(runCalls, [
+      {
+        homey,
+        clean: false,
+        skipBuild: false,
+        linkModules: '',
+        network: undefined,
+        dockerSocketPath: undefined,
+        findLinks: undefined,
+        dockerExposedPorts: ['5683/udp'],
+      },
+    ]);
+  });
+
   it('rejects legacy Homey API clients', async (t) => {
     const appPath = await copyFixtureApp(t, 'python-basic');
     const app = new AppPython(appPath);

--- a/tests/app/runner-container.test.mjs
+++ b/tests/app/runner-container.test.mjs
@@ -68,6 +68,7 @@ describe('runner container characterization', () => {
       '/tmp/homey-userdata',
       linkedModulePath,
       docker,
+      DockerHelper.createPortConfiguration([6113, '5683/udp']),
     );
 
     assert.strictEqual(calls.run.length, 1);
@@ -79,7 +80,14 @@ describe('runner container characterization', () => {
     assert.ok(run.options.Env.includes('DEVMODE=1'));
     assert.strictEqual(run.options.Labels['com.athom.app-runtime'], 'nodejs');
     assert.strictEqual(run.options.HostConfig.NetworkMode, 'fixture-network');
+    assert.deepStrictEqual(run.options.ExposedPorts, {
+      '6113/tcp': {},
+      '5683/udp': {},
+      '9229/tcp': {},
+    });
     assert.deepStrictEqual(run.options.HostConfig.PortBindings['9229/tcp'], [{ HostPort: '9229' }]);
+    assert.deepStrictEqual(run.options.HostConfig.PortBindings['6113/tcp'], [{ HostPort: '6113' }]);
+    assert.deepStrictEqual(run.options.HostConfig.PortBindings['5683/udp'], [{ HostPort: '5683' }]);
     assert.ok(run.options.HostConfig.Binds.includes(`${app._homeyBuildPath}:/app:ro,z`));
     assert.ok(run.options.HostConfig.Binds.includes('/tmp/homey-fixture:/tmp:rw,z'));
     assert.ok(run.options.HostConfig.Binds.includes('/tmp/homey-userdata:/userdata:rw,z'));
@@ -118,6 +126,7 @@ describe('runner container characterization', () => {
       '/tmp/python-userdata',
       '',
       docker,
+      DockerHelper.createPortConfiguration([6113, '5683/udp']),
     );
 
     const run = calls.run[0];
@@ -125,6 +134,14 @@ describe('runner container characterization', () => {
     assert.deepStrictEqual(run.command, ['bash', 'entrypoint.sh']);
     assert.strictEqual(run.options.Labels['com.athom.app-runtime'], 'python');
     assert.strictEqual(run.options.HostConfig.NetworkMode, 'bridge');
+    assert.deepStrictEqual(run.options.ExposedPorts, {
+      '6113/tcp': {},
+      '5683/udp': {},
+    });
+    assert.deepStrictEqual(run.options.HostConfig.PortBindings, {
+      '6113/tcp': [{ HostPort: '6113' }],
+      '5683/udp': [{ HostPort: '5683' }],
+    });
     assert.ok(run.options.HostConfig.Binds.includes(`${app._homeyBuildPath}:/app`));
     assert.ok(run.options.HostConfig.Binds.includes('/tmp/python-userdata:/userdata:rw,z'));
 
@@ -169,5 +186,19 @@ describe('runner container characterization', () => {
         return actualError === error;
       },
     );
+  });
+
+  it('rejects invalid published ports before connecting to Docker', async (t) => {
+    const appPath = await copyFixtureApp(t, 'node-basic');
+    const app = new App(appPath);
+    const ensureDocker = t.mock.method(DockerHelper, 'ensureDocker', async () => {
+      throw new Error('Docker must not be contacted');
+    });
+
+    await assert.rejects(() => {
+      return app.runDocker({ dockerExposedPorts: ['65536/tcp'] });
+    }, /Port must be between 1 and 65535/);
+
+    assert.strictEqual(ensureDocker.mock.callCount(), 0);
   });
 });

--- a/tests/app/runner-container.test.mjs
+++ b/tests/app/runner-container.test.mjs
@@ -187,18 +187,4 @@ describe('runner container characterization', () => {
       },
     );
   });
-
-  it('rejects invalid published ports before connecting to Docker', async (t) => {
-    const appPath = await copyFixtureApp(t, 'node-basic');
-    const app = new App(appPath);
-    const ensureDocker = t.mock.method(DockerHelper, 'ensureDocker', async () => {
-      throw new Error('Docker must not be contacted');
-    });
-
-    await assert.rejects(() => {
-      return app.runDocker({ dockerExposedPorts: ['65536/tcp'] });
-    }, /Port must be between 1 and 65535/);
-
-    assert.strictEqual(ensureDocker.mock.callCount(), 0);
-  });
 });

--- a/tests/cli/app-handlers.test.mjs
+++ b/tests/cli/app-handlers.test.mjs
@@ -100,6 +100,7 @@ describe('CLI app handler characterization', () => {
       network: 'host',
       dockerSocketPath: '/tmp/docker.sock',
       findLinks: '/wheels',
+      dockerExposedPorts: ['6113/tcp', '5683/udp'],
     });
 
     assert.deepStrictEqual(calls, [
@@ -111,6 +112,7 @@ describe('CLI app handler characterization', () => {
         network: 'host',
         dockerSocketPath: '/tmp/docker.sock',
         findLinks: '/wheels',
+        dockerExposedPorts: ['6113/tcp', '5683/udp'],
       },
     ]);
     assert.deepStrictEqual(exits, []);

--- a/tests/lib/docker-helper.test.mjs
+++ b/tests/lib/docker-helper.test.mjs
@@ -9,6 +9,30 @@ import Settings from '../../services/Settings.js';
 import { createFakeDocker } from '../app/fakes.mjs';
 
 describe('DockerHelper characterization', () => {
+  it('normalizes Docker port specifications into exposed ports and host bindings', () => {
+    const configuration = DockerHelper.createPortConfiguration([6113, '5683/udp']);
+
+    assert.deepStrictEqual(configuration, {
+      exposedPorts: {
+        '6113/tcp': {},
+        '5683/udp': {},
+      },
+      portBindings: {
+        '6113/tcp': [{ HostPort: '6113' }],
+        '5683/udp': [{ HostPort: '5683' }],
+      },
+      publishedPorts: ['6113/tcp', '5683/udp'],
+    });
+  });
+
+  it('rejects malformed and out-of-range Docker port specifications', () => {
+    for (const portSpec of ['5683/sctp', 'tcp/5683', 0, 65536]) {
+      assert.throws(() => {
+        DockerHelper.createPortConfiguration([portSpec]);
+      }, /Invalid Docker port/);
+    }
+  });
+
   it('constructs and pings Docker through a custom socket', async (t) => {
     const ping = t.mock.method(Docker.prototype, 'ping', async () => {});
 

--- a/tests/lib/docker-helper.test.mjs
+++ b/tests/lib/docker-helper.test.mjs
@@ -22,6 +22,7 @@ describe('DockerHelper characterization', () => {
         '5683/udp': [{ HostPort: '5683' }],
       },
       publishedPorts: ['6113/tcp', '5683/udp'],
+      publishedTcpPorts: [6113],
     });
   });
 

--- a/tests/lib/docker-helper.test.mjs
+++ b/tests/lib/docker-helper.test.mjs
@@ -26,6 +26,10 @@ describe('DockerHelper characterization', () => {
   });
 
   it('rejects malformed and out-of-range Docker port specifications', () => {
+    assert.throws(() => {
+      DockerHelper.createPortConfiguration('5683/udp');
+    }, /must be an array/);
+
     for (const portSpec of ['5683/sctp', 'tcp/5683', 0, 65536]) {
       assert.throws(() => {
         DockerHelper.createPortConfiguration([portSpec]);


### PR DESCRIPTION
Reimplements and extends #573 on top of the current develop branch. Credit to @bobvandevijver for the original implementation and use case.

## Summary

- add the docker-exposed-ports option for local app runs
- publish TCP and UDP ports on the same host port
- support both Node.js and Python app runners
- normalize bare ports to TCP and reject malformed or out-of-range ports before Docker is contacted
- document host-interface and firewall implications in the CLI help
- add coverage for CLI forwarding, runtime routing, Docker configuration, and validation

## Validation

- npm run lint
- npm test (239 tests passing)
- git diff --check