### PR TITLE
Fix target version npm publish dry run

### DIFF
--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -166,10 +166,17 @@ jobs:
           fi
 
       - name: Run release checks
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next }}
         run: |
+          set -euo pipefail
+
           npm run prettier:check
           npm run lint
           npm run test:coverage
+
+          trap 'git restore -- package.json package-lock.json' EXIT
+          npm version "$NEXT_VERSION" --no-git-tag-version --ignore-scripts
           npm publish --dry-run --registry https://registry.npmjs.org
 
       - name: Create and push version


### PR DESCRIPTION
## Summary

- temporarily apply the calculated target version before the npm publish dry run
- restore package.json and package-lock.json after the preflight on success or failure
- leave the real version commit and atomic tag push unchanged

## Verification

- formatting and lint pass
- coverage suite passes
- npm dry-run succeeds for homey@4.4.4
- both package files restore to 4.4.3 after successful and failed preflight simulations