### PR TITLE
Group GitHub workflows by purpose

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI - Lint
 
 # Version: 2.0.1
 # Modified: No

--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -1,4 +1,4 @@
-name: Update Package Version
+name: Release - Create Version
 
 on:
   workflow_dispatch:

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,4 +1,4 @@
-name: Promote Published Release
+name: Release - Promote to Production
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-package-npm.yml
+++ b/.github/workflows/publish-package-npm.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Release - Publish to npm
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI - Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-homey-lib.yml
+++ b/.github/workflows/update-homey-lib.yml
@@ -1,4 +1,4 @@
-name: Update homey-lib
+name: Maintenance - Update homey-lib
 
 # About this workflow:
 # This workflow is triggered by a 'repository_dispatch' event, this event can be triggered using an API call or using


### PR DESCRIPTION
## Summary

Use consistent category prefixes so repository workflows group together in the GitHub Actions sidebar:

- `CI - Lint` and `CI - Test`
- `Release - Create Version`, `Release - Promote to Production`, and `Release - Publish to npm`
- `Maintenance - Update homey-lib`

GitHub-managed Copilot workflows are unchanged.