### PR TITLE
add --discovery-strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ source ~/.zshrc
 
 Use `homey api` for direct Homey API access.
 
+Use the global `--discovery-strategies` option to restrict Homey discovery for app and API
+commands. Supported values are `cloud`, `local`, `localSecure`, `remoteForwarded`, and `mdns`.
+Omitting the option keeps the default discovery behavior. Token mode uses its resolved address
+directly and does not use discovery strategies.
+
+```bash
+homey api raw --path /api/manager/system/ --discovery-strategies cloud,local,mdns
+homey app run --discovery-strategies local
+homey api diagnose --discovery-strategies cloud,mdns
+```
+
 ### Raw requests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,17 +85,6 @@ source ~/.zshrc
 
 Use `homey api` for direct Homey API access.
 
-Use the global `--discovery-strategies` option to restrict Homey discovery for app and API
-commands. Supported values are `cloud`, `local`, `localSecure`, `remoteForwarded`, and `mdns`.
-Omitting the option keeps the default discovery behavior. Token mode uses its resolved address
-directly and does not use discovery strategies.
-
-```bash
-homey api raw --path /api/manager/system/ --discovery-strategies cloud,local,mdns
-homey app run --discovery-strategies local
-homey api diagnose --discovery-strategies cloud,mdns
-```
-
 ### Raw requests
 
 ```bash

--- a/bin/homey.mjs
+++ b/bin/homey.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import updateNotifier from 'update-notifier';
 import semver from 'semver';
 import yargs from 'yargs';
+import { HomeyAPI } from 'homey-api';
 import { aliases as rawCommandAliases } from './cmds/api/raw.mjs';
 import {
   getHomeyManagerDefinition,
@@ -16,6 +17,7 @@ import { loadHomeyManagerCommandExtension } from '../lib/api/ApiManagerExtension
 import { getManagerCommandNames } from '../lib/api/ApiManagerCommand.mjs';
 import Log from '../lib/Log.js';
 import AthomMessage from '../services/AthomMessage.js';
+import AthomApi from '../services/AthomApi.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 const COMMANDS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'cmds');
@@ -218,6 +220,25 @@ await yargs(normalizedArgs)
   .version('version', 'Show version number', pkg.version)
   .alias('version', 'v')
   .global(['version', 'v'], false)
+  .option('discovery-strategies', {
+    type: 'string',
+    requiresArg: true,
+    description:
+      'Comma-separated discovery strategies: cloud, local, localSecure, remoteForwarded, mdns',
+    coerce: (value) => {
+      const strategies = value.split(',').map((strategy) => strategy.trim());
+      const supportedStrategies = Object.values(HomeyAPI.DISCOVERY_STRATEGIES);
+      if (strategies.some((strategy) => !supportedStrategies.includes(strategy))) {
+        throw new Error(
+          `Invalid --discovery-strategies. Supported values: ${supportedStrategies.join(', ')}.`,
+        );
+      }
+      return [...new Set(strategies)];
+    },
+  })
+  .middleware((argv) => {
+    AthomApi.discoveryStrategies = argv.discoveryStrategies;
+  })
   .commandDir('./cmds', {
     extensions: ['.mjs'],
   })

--- a/lib/AthomApi.js
+++ b/lib/AthomApi.js
@@ -33,6 +33,7 @@ class AthomApi {
     this._user = null;
     this._homeys = null;
     this._activeHomey = null;
+    this.discoveryStrategies = undefined;
   }
 
   _createApi() {
@@ -224,7 +225,7 @@ class AthomApi {
       }
 
       const homey = await this.getHomey(activeHomey.id);
-      const strategy = getPreferredActiveHomeyStrategy(homey);
+      const strategy = this.discoveryStrategies ?? getPreferredActiveHomeyStrategy(homey);
       const homeyApi = await homey.authenticate({ strategy }).catch((err) => {
         if (err instanceof APIErrorHomeyOffline) {
           throw new Error(
@@ -234,7 +235,7 @@ class AthomApi {
         throw err;
       });
 
-      if (homey.usb) {
+      if (homey.usb && !this.discoveryStrategies) {
         homeyApi.__baseUrlPromise = Promise.resolve(`http://${homey.usb}:80`);
       }
 

--- a/lib/api/ApiCommandRuntime.mjs
+++ b/lib/api/ApiCommandRuntime.mjs
@@ -73,8 +73,8 @@ function createTokenHomeyApi({ token, address, homeyId = 'token-homey' }) {
   });
 }
 
-function applyResolvedHomeyMetadata(homeyApi, homey) {
-  if (homey.usb) {
+function applyResolvedHomeyMetadata(homeyApi, homey, { useUsb = true } = {}) {
+  if (homey.usb && useUsb) {
     // Keep USB override behavior in sync with existing AthomApi implementation.
     homeyApi.__baseUrlPromise = Promise.resolve(`http://${homey.usb}:80`);
   }
@@ -84,6 +84,10 @@ function applyResolvedHomeyMetadata(homeyApi, homey) {
 }
 
 export function getPreferredAuthenticateStrategy(homey) {
+  if (AthomApi.discoveryStrategies) {
+    return AthomApi.discoveryStrategies;
+  }
+
   if (homey.platform === HomeyAPI.PLATFORMS.CLOUD) {
     return [HomeyAPI.DISCOVERY_STRATEGIES.CLOUD];
   }
@@ -99,7 +103,7 @@ export function getPreferredAuthenticateStrategy(homey) {
 function getDiagnoseStrategyOrder(homey) {
   const preferredStrategies = getPreferredAuthenticateStrategy(homey);
 
-  if (homey.platform === HomeyAPI.PLATFORMS.CLOUD) {
+  if (AthomApi.discoveryStrategies || homey.platform === HomeyAPI.PLATFORMS.CLOUD) {
     return preferredStrategies;
   }
 
@@ -148,7 +152,9 @@ async function authenticateHomey(homey, strategy = getPreferredAuthenticateStrat
     const homeyApi = await homey.authenticate({
       strategy,
     });
-    return applyResolvedHomeyMetadata(homeyApi, homey);
+    return applyResolvedHomeyMetadata(homeyApi, homey, {
+      useUsb: !AthomApi.discoveryStrategies,
+    });
   } catch (err) {
     if (err instanceof APIErrorHomeyOffline) {
       throw normalizeOfflineError(homey);

--- a/tests/cli/api-homey.test.mjs
+++ b/tests/cli/api-homey.test.mjs
@@ -26,6 +26,33 @@ const DYNAMIC_MANAGER_SCENARIOS = [
 ];
 
 describe('CLI api', () => {
+  it('accepts comma-separated discovery strategies before and after the command', (t) => {
+    const homeyHome = createIsolatedHomeyHome();
+    t.after(() => removeHomeyHome(homeyHome));
+
+    for (const args of [
+      ['--discovery-strategies', 'cloud, local,mdns', 'api', 'schema', '--json'],
+      ['api', 'schema', '--json', '--discovery-strategies', 'localSecure,remoteForwarded'],
+    ]) {
+      assertSuccess(runHomey(args, homeyHome), args.join(' '));
+    }
+  });
+
+  it('rejects unknown, empty, and missing discovery strategies', (t) => {
+    const homeyHome = createIsolatedHomeyHome();
+    t.after(() => removeHomeyHome(homeyHome));
+
+    for (const value of ['cloud,invalid', '', 'local,']) {
+      const result = runHomey(['api', 'schema', '--discovery-strategies', value], homeyHome);
+      assert.strictEqual(result.status, 1);
+      assert.match(result.stderr, /Invalid --discovery-strategies/);
+    }
+
+    const result = runHomey(['api', 'schema', '--discovery-strategies'], homeyHome);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /Not enough arguments following: discovery-strategies/);
+  });
+
   it('lists all supported managers in completion', (t) => {
     const homeyHome = createIsolatedHomeyHome();
     t.after(() => removeHomeyHome(homeyHome));

--- a/tests/lib/api-command-runtime.test.mjs
+++ b/tests/lib/api-command-runtime.test.mjs
@@ -8,9 +8,27 @@ import { createHomeyApiClient, diagnoseHomeyStrategies } from '../../lib/api/Api
 
 afterEach(() => {
   mock.restoreAll();
+  AthomApi.discoveryStrategies = undefined;
 });
 
 describe('ApiCommandRuntime createHomeyApiClient', () => {
+  it('uses explicit discovery strategies without overriding the route with USB', async () => {
+    AthomApi.discoveryStrategies = ['cloud', 'local', 'mdns'];
+    const authenticate = mock.fn(async () => ({}));
+    mock.method(AthomApi, 'getHomey', async () => ({
+      id: 'target-homey',
+      usb: '10.0.0.1',
+      authenticate,
+    }));
+
+    const result = await createHomeyApiClient({ homeyId: 'target-homey' });
+
+    assert.deepStrictEqual(authenticate.mock.calls[0].arguments, [
+      { strategy: ['cloud', 'local', 'mdns'] },
+    ]);
+    assert.strictEqual(result.__baseUrlPromise, undefined);
+  });
+
   it('authenticates the requested Homey id instead of the selected Homey', async () => {
     const authenticatedApi = {};
     const authenticateCalls = [];
@@ -143,6 +161,25 @@ describe('ApiCommandRuntime createHomeyApiClient', () => {
 });
 
 describe('ApiCommandRuntime diagnoseHomeyStrategies', () => {
+  it('diagnoses only the explicitly requested strategies', async () => {
+    AthomApi.discoveryStrategies = ['cloud', 'local'];
+    const authenticate = mock.fn(async () => ({}));
+    mock.method(AthomApi, 'getHomey', async () => ({
+      id: 'target-homey',
+      platform: HomeyAPI.PLATFORMS.LOCAL,
+      authenticate,
+    }));
+
+    const report = await diagnoseHomeyStrategies({ homeyId: 'target-homey' });
+
+    assert.deepStrictEqual(report.preferredStrategyIds, ['cloud', 'local']);
+    assert.deepStrictEqual(report.attemptedStrategyIds, ['cloud', 'local']);
+    assert.deepStrictEqual(
+      authenticate.mock.calls.map((call) => call.arguments),
+      [[{ strategy: ['cloud'] }], [{ strategy: ['local'] }]],
+    );
+  });
+
   it('tests each local strategy and reports successful routes', async () => {
     const authenticateCalls = [];
     const cleanupCalls = [];

--- a/tests/lib/athom-api.selection.test.mjs
+++ b/tests/lib/athom-api.selection.test.mjs
@@ -11,6 +11,23 @@ afterEach(() => {
 });
 
 describe('AthomApi selected Homey persistence', () => {
+  it('uses explicit discovery strategies without overriding the route with USB', async () => {
+    const athomApi = new AthomApi();
+    athomApi.discoveryStrategies = ['cloud', 'mdns'];
+    const authenticate = mock.fn(async () => ({}));
+    mock.method(Settings, 'get', async () => ({ id: 'homey-id' }));
+    mock.method(athomApi, 'getHomey', async () => ({
+      id: 'homey-id',
+      usb: '10.0.0.1',
+      authenticate,
+    }));
+
+    const result = await athomApi.getActiveHomey();
+
+    assert.deepStrictEqual(authenticate.mock.calls[0].arguments, [{ strategy: ['cloud', 'mdns'] }]);
+    assert.strictEqual(result.__baseUrlPromise, undefined);
+  });
+
   it('persists platform alongside id and name', async () => {
     const athomApi = new AthomApi();
     const settingsSet = mock.method(Settings, 'set', async (key, value) => {


### PR DESCRIPTION
This PR makes it easier to specifiy which Homey Discovery Strategies must be used.

For example:

```bash
$ homey app run --discovery-strategies cloud,local
```

It's a nice to have for sure. I used it to test the upcoming `homey app run` through Homey Connect.