### PR TITLE
feat: add explicit app build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,68 @@ $ homey --help
 
 Or read the [getting started](https://apps.developer.homey.app/the-basics/getting-started) documentation.
 
+## App build scripts
+
+Control whether the CLI runs your Node.js app's build script with `homey.build` in the
+app's `package.json`:
+
+```json
+{
+  "homey": {
+    "build": true
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}
+```
+
+| `homey.build` | Behavior                                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `true`        | Run `npm run build` from the app directory. Requires a nonempty `scripts.build`.                                                     |
+| `false`       | Skip the app build script and TypeScript configuration checks.                                                                       |
+| Omitted       | Preserve automatic compilation when `devDependencies.typescript` is present, including the existing TypeScript configuration checks. |
+
+Explicit builds can use TypeScript, a bundler, or another tool. The CLI does not inspect
+`tsconfig.json` when `homey.build` is explicitly set. Other values, including the string
+`"false"`, are rejected.
+
+Homey first generates the Compose manifest, clears `.homeybuild`, and copies source files
+and production dependencies into it. Your build script then adds or overwrites generated
+deployment files in `.homeybuild`. Preserve the staged manifest, assets, and dependencies;
+do not clear the output directory in your script. Existing postprocessing and validation
+still apply. Build script failures stop the build.
+
+For a JavaScript app using TypeScript solely to check JSDoc, use:
+
+```json
+{
+  "homey": {
+    "build": false
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}
+```
+
+You can install the normal `typescript` development dependency and run `npm run typecheck`
+independently. Editor checking remains available. Unlike `--skip-build`, which skips
+preprocessing, `homey.build: false` still allows Compose generation, source and dependency
+copying, and normal validation.
+
+New JavaScript apps explicitly disable the build script; new TypeScript apps explicitly
+enable it. Driver template language is independent of this setting: outside the existing
+ESM template branch, the CLI checks an existing `main` entry outside `.homeybuild`, then
+root `app.js`/`app.mjs`/`app.cjs` or `app.ts`/`app.mts`/`app.cts` files. Ambiguous or absent
+source files fall back to dependency detection.
+
+Older CLI versions ignore `homey.build`; use a CLI release that supports this setting in
+both local development and CI. Support is currently unreleased. A future breaking release
+may make builds opt-in, but omitted settings retain their existing behavior in this release.
+Disabling compilation does not enable native TypeScript execution: TypeScript source files
+are still excluded from the deployment copy. Python app builds are unchanged.
+
 ## Testing
 
 Run the hermetic test suite without a Homey, account credentials, network access, or Docker:

--- a/lib/App.js
+++ b/lib/App.js
@@ -89,13 +89,64 @@ class App {
     return false;
   }
 
+  static getBuildMode({ appPath }) {
+    let pkg;
+    try {
+      pkg = fse.readJSONSync(path.join(appPath, 'package.json'));
+    } catch (error) {
+      return 'none';
+    }
+
+    const build = pkg?.homey?.build;
+
+    if (build === undefined) {
+      return pkg?.devDependencies?.typescript ? 'typescript' : 'none';
+    }
+
+    if (typeof build !== 'boolean') {
+      throw new Error('Expected `homey.build` in package.json to be a boolean.');
+    }
+
+    if (!build) {
+      return 'none';
+    }
+
+    const buildScript = pkg?.scripts?.build;
+
+    if (typeof buildScript !== 'string' || buildScript.trim() === '') {
+      throw new Error('`homey.build: true` requires a nonempty `scripts.build` in package.json.');
+    }
+
+    return 'script';
+  }
+
+  static async runBuildScript({ appPath }) {
+    Log.success('Running app build script...');
+
+    try {
+      await exec('npm run build', { cwd: appPath });
+    } catch (error) {
+      Log.error(error);
+      if (error.stdout) {
+        Log(error.stdout);
+      }
+      if (error.stderr) {
+        Log(error.stderr);
+      }
+
+      throw new Error('App build failed.', { cause: error });
+    }
+
+    Log.success('App build script successful');
+  }
+
   static async transpileToTypescript({ appPath }) {
     Log.success('Typescript detected. Compiling...');
 
     try {
       let tsconfig;
       try {
-        const { stdout } = await exec('npx tsc --showConfig');
+        const { stdout } = await exec('npx tsc --showConfig', { cwd: appPath });
         tsconfig = JSON.parse(stdout);
       } catch (error) {
         throw new Error(
@@ -884,6 +935,8 @@ $ sudo systemctl restart docker
   }
 
   async preprocess({ copyAppProductionDependencies = true } = {}) {
+    const buildMode = App.getBuildMode({ appPath: this.path });
+
     if (App.hasHomeyCompose({ appPath: this.path }) === false) {
       // Note: this checks that we are in a valid homey app folder
       App.getManifest({ appPath: this.path });
@@ -913,8 +966,10 @@ $ sudo systemctl restart docker
       await this._copyAppProductionDependencies();
     }
 
-    // Compile TypeScript files to .homeybuild/
-    if (App.usesTypeScript({ appPath: this.path })) {
+    // Explicit scripts own compilation; omitted settings retain legacy TypeScript checks.
+    if (buildMode === 'script') {
+      await App.runBuildScript({ appPath: this.path });
+    } else if (buildMode === 'typescript') {
       await App.transpileToTypescript({ appPath: this.path });
     }
 
@@ -2227,7 +2282,7 @@ $ sudo systemctl restart docker
         path.join(driverPath, 'device.js'),
       );
     } else {
-      const fileExtension = App.usesTypeScript({ appPath: this.path }) ? '.ts' : '.js';
+      const fileExtension = App.usesTypeScriptSource({ appPath: this.path }) ? '.ts' : '.js';
       await copyFileAsync(
         path.join(templatePath, `driver${fileExtension}`),
         path.join(driverPath, `driver${fileExtension}`),
@@ -2237,6 +2292,55 @@ $ sudo systemctl restart docker
         path.join(driverPath, `device${fileExtension}`),
       );
     }
+  }
+
+  static usesTypeScriptSource({ appPath }) {
+    const languages = new Map([
+      ['.js', 'javascript'],
+      ['.mjs', 'javascript'],
+      ['.cjs', 'javascript'],
+      ['.ts', 'typescript'],
+      ['.mts', 'typescript'],
+      ['.cts', 'typescript'],
+    ]);
+    let pkg;
+    try {
+      pkg = fse.readJSONSync(path.join(appPath, 'package.json'));
+    } catch (error) {
+      // Source files can still identify the language without a valid package.json.
+    }
+
+    if (typeof pkg?.main === 'string') {
+      const mainPath = path.resolve(appPath, pkg.main);
+      const buildPath = path.resolve(appPath, '.homeybuild');
+      const isBuildOutput =
+        mainPath === buildPath || mainPath.startsWith(`${buildPath}${path.sep}`);
+      const language = languages.get(path.extname(mainPath));
+
+      if (
+        !isBuildOutput &&
+        language &&
+        fs.statSync(mainPath, { throwIfNoEntry: false })?.isFile()
+      ) {
+        return language === 'typescript';
+      }
+    }
+
+    const sourceLanguages = new Set();
+
+    for (const [extension, language] of languages) {
+      const sourcePath = path.join(appPath, `app${extension}`);
+
+      if (fs.statSync(sourcePath, { throwIfNoEntry: false })?.isFile()) {
+        sourceLanguages.add(language);
+      }
+    }
+
+    if (sourceLanguages.size === 1) {
+      return sourceLanguages.has('typescript');
+    }
+
+    return App.usesTypeScript({ appPath });
   }
 
   async questionDriverWireless() {
@@ -3581,6 +3685,9 @@ $ sudo systemctl restart docker
       name: answers.id,
       version: '1.0.0',
       main: 'app.js',
+      homey: {
+        build: answers.typescript,
+      },
       scripts: {
         build: undefined,
         lint: answers.eslint ? 'eslint --ext .js,.ts --ignore-path .gitignore .' : undefined,

--- a/tests/app/build-config.test.mjs
+++ b/tests/app/build-config.test.mjs
@@ -1,0 +1,242 @@
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import App from '../../lib/App.js';
+import NpmCommands from '../../lib/NpmCommands.js';
+import { copyFixtureApp, listTree } from './helpers.mjs';
+
+describe('app build configuration', () => {
+  for (const typescript of [undefined, '^5.0.0']) {
+    for (const build of [undefined, false, true]) {
+      it(`resolves build=${build} with typescript=${typescript}`, async (t) => {
+        const appPath = await copyFixtureApp(t, 'node-basic');
+        await fs.writeFile(
+          path.join(appPath, 'package.json'),
+          JSON.stringify({
+            homey: { build },
+            devDependencies: { typescript },
+            scripts: { build: 'node build.cjs' },
+          }),
+        );
+        let expected = 'none';
+        if (build === true) {
+          expected = 'script';
+        } else if (build === undefined && typescript) {
+          expected = 'typescript';
+        }
+
+        assert.strictEqual(App.getBuildMode({ appPath }), expected);
+      });
+    }
+  }
+
+  for (const contents of [undefined, '{', 'null', '{}']) {
+    it(`retains no-build handling for package contents ${contents}`, async (t) => {
+      const appPath = await copyFixtureApp(t, 'node-basic');
+      if (contents !== undefined) {
+        await fs.writeFile(path.join(appPath, 'package.json'), contents);
+      }
+
+      assert.strictEqual(App.getBuildMode({ appPath }), 'none');
+    });
+  }
+
+  for (const build of ['false', 'true', 0, 1, null, {}, []]) {
+    it(`rejects invalid build setting ${JSON.stringify(build)} before modifying the app`, async (t) => {
+      const appPath = await copyFixtureApp(t, 'node-compose-esm');
+      const manifestPath = path.join(appPath, 'app.json');
+      await fs.writeFile(manifestPath, 'previous manifest');
+      await fs.mkdir(path.join(appPath, '.homeybuild'));
+      const sentinelPath = path.join(appPath, '.homeybuild', 'previous.txt');
+      await fs.writeFile(sentinelPath, 'previous build');
+      await fs.writeFile(path.join(appPath, 'package.json'), JSON.stringify({ homey: { build } }));
+
+      await assert.rejects(new App(appPath).preprocess(), /homey\.build.*boolean/);
+      assert.strictEqual(await fs.readFile(manifestPath, 'utf8'), 'previous manifest');
+      assert.strictEqual(await fs.readFile(sentinelPath, 'utf8'), 'previous build');
+    });
+  }
+
+  for (const buildScript of [undefined, '', '  \n', false, 42]) {
+    it(`requires a nonempty script when explicitly enabled: ${JSON.stringify(buildScript)}`, async (t) => {
+      const appPath = await copyFixtureApp(t, 'node-basic');
+      await fs.writeFile(
+        path.join(appPath, 'package.json'),
+        JSON.stringify({ homey: { build: true }, scripts: { build: buildScript } }),
+      );
+
+      await assert.rejects(new App(appPath).preprocess(), /requires a nonempty `scripts\.build`/);
+      await assert.rejects(fs.access(path.join(appPath, '.homeybuild')), { code: 'ENOENT' });
+    });
+  }
+
+  it('runs a tool-independent build in the app directory and preserves staged files', async (t) => {
+    const appPath = await copyFixtureApp(t, 'node-basic');
+    await fs.writeFile(
+      path.join(appPath, 'package.json'),
+      JSON.stringify({ homey: { build: true }, scripts: { build: 'node build.cjs' } }),
+    );
+    await fs.writeFile(
+      path.join(appPath, 'build.cjs'),
+      `
+const fs = require('node:fs');
+for (const file of ['app.json', 'assets/icon.svg', 'node_modules/fixture/value.txt']) {
+  fs.accessSync('.homeybuild/' + file);
+}
+fs.writeFileSync('.homeybuild/generated.txt', process.cwd());
+fs.writeFileSync('.homeybuild/app.js', '// generated application');
+`,
+    );
+    await fs.mkdir(path.join(appPath, 'node_modules', 'fixture'), { recursive: true });
+    await fs.writeFile(
+      path.join(appPath, 'node_modules', 'fixture', 'value.txt'),
+      'production dependency',
+    );
+    t.mock.method(NpmCommands, 'getProductionDependencies', async () => {
+      return ['node_modules/fixture'];
+    });
+    t.mock.method(App, 'transpileToTypescript', async () => {
+      assert.fail('Explicit builds must not invoke TypeScript configuration checks');
+    });
+
+    await new App(appPath).build();
+
+    assert.strictEqual(
+      await fs.readFile(path.join(appPath, '.homeybuild/generated.txt'), 'utf8'),
+      appPath,
+    );
+    assert.strictEqual(
+      await fs.readFile(path.join(appPath, '.homeybuild/app.js'), 'utf8'),
+      '// generated application',
+    );
+    assert.strictEqual(
+      await fs.readFile(path.join(appPath, '.homeybuild/node_modules/fixture/value.txt'), 'utf8'),
+      'production dependency',
+    );
+    await assert.rejects(fs.access(path.join(appPath, 'tsconfig.json')), { code: 'ENOENT' });
+  });
+
+  it('keeps Compose, dependency copying, postprocessing, and validation when opted out', async (t) => {
+    const appPath = await copyFixtureApp(t, 'node-compose-esm');
+    await fs.writeFile(
+      path.join(appPath, 'package.json'),
+      JSON.stringify({
+        type: 'module',
+        homey: { build: false },
+        devDependencies: { typescript: '*' },
+        scripts: { build: 'node missing-build-script.cjs' },
+      }),
+    );
+    await fs.writeFile(path.join(appPath, 'app.json'), '{}');
+    await fs.mkdir(path.join(appPath, 'node_modules', 'fixture'), { recursive: true });
+    await fs.writeFile(path.join(appPath, 'node_modules', 'fixture', 'value.txt'), 'dependency');
+    t.mock.method(NpmCommands, 'getProductionDependencies', async () => {
+      return ['node_modules/fixture'];
+    });
+    t.mock.method(App, 'transpileToTypescript', async () => {
+      assert.fail('Opted-out apps must not compile');
+    });
+    const app = new App(appPath);
+
+    await app.build();
+
+    const buildPath = path.join(appPath, '.homeybuild');
+    const manifest = JSON.parse(await fs.readFile(path.join(buildPath, 'app.json'), 'utf8'));
+    const pkg = JSON.parse(await fs.readFile(path.join(buildPath, 'package.json'), 'utf8'));
+    assert.strictEqual(manifest.drivers[0].id, 'fixture');
+    assert.strictEqual(pkg.type, 'module');
+    const tree = await listTree(buildPath);
+    assert.ok(tree.includes('app.js'));
+    assert.ok(tree.includes('node_modules/fixture/value.txt'));
+    await fs.rm(path.join(buildPath, 'assets/icon.svg'));
+    await assert.rejects(app.validate(), /assets.*icon\.svg/);
+  });
+
+  it('retains build diagnostics and stops before postprocessing on script failure', async (t) => {
+    const appPath = await copyFixtureApp(t, 'node-basic');
+    await fs.writeFile(path.join(appPath, '.gitignore'), '/node_modules/');
+    await fs.writeFile(
+      path.join(appPath, 'package.json'),
+      JSON.stringify({ homey: { build: true }, scripts: { build: 'node build.cjs' } }),
+    );
+    await fs.writeFile(
+      path.join(appPath, 'build.cjs'),
+      "console.log('build stdout'); console.error('build stderr'); process.exit(7);\n",
+    );
+
+    await assert.rejects(
+      new App(appPath).preprocess({ copyAppProductionDependencies: false }),
+      (error) => {
+        assert.strictEqual(error.message, 'App build failed.');
+        assert.strictEqual(error.cause.code, 7);
+        assert.match(error.cause.stdout, /build stdout/);
+        assert.match(error.cause.stderr, /build stderr/);
+        return true;
+      },
+    );
+    assert.strictEqual(
+      await fs.readFile(path.join(appPath, '.gitignore'), 'utf8'),
+      '/node_modules/',
+    );
+  });
+
+  it('retains legacy TypeScript configuration checks in the app directory', async (t) => {
+    const appPath = await copyFixtureApp(t, 'node-basic');
+    const previousOffline = process.env.npm_config_offline;
+    process.env.npm_config_offline = 'true';
+    t.after(() => {
+      if (previousOffline === undefined) {
+        delete process.env.npm_config_offline;
+      } else {
+        process.env.npm_config_offline = previousOffline;
+      }
+    });
+    await fs.writeFile(
+      path.join(appPath, 'package.json'),
+      JSON.stringify({
+        devDependencies: { typescript: '*' },
+        scripts: { build: 'node build.cjs' },
+      }),
+    );
+    await fs.writeFile(
+      path.join(appPath, 'build.cjs'),
+      "require('node:fs').writeFileSync('.homeybuild/compiled.txt', process.cwd());\n",
+    );
+    await fs.mkdir(path.join(appPath, 'node_modules/.bin'), { recursive: true });
+    await fs.writeFile(
+      path.join(appPath, 'node_modules/.bin/tsc'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.writeFileSync('config-cwd.txt', process.cwd());
+process.stdout.write(fs.readFileSync('tsconfig.json', 'utf8'));
+`,
+      { mode: 0o755 },
+    );
+    await fs.writeFile(
+      path.join(appPath, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { outDir: './.homeybuild' } }),
+    );
+    const app = new App(appPath);
+
+    await app.preprocess({ copyAppProductionDependencies: false });
+
+    assert.strictEqual(await fs.readFile(path.join(appPath, 'config-cwd.txt'), 'utf8'), appPath);
+    assert.strictEqual(
+      await fs.readFile(path.join(appPath, '.homeybuild/compiled.txt'), 'utf8'),
+      appPath,
+    );
+    await fs.writeFile(
+      path.join(appPath, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { outDir: './dist' } }),
+    );
+    await assert.rejects(
+      app.preprocess({ copyAppProductionDependencies: false }),
+      /Typescript compilation failed/,
+    );
+    await assert.rejects(fs.access(path.join(appPath, '.homeybuild/compiled.txt')), {
+      code: 'ENOENT',
+    });
+  });
+});

--- a/tests/app/create.test.mjs
+++ b/tests/app/create.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import inquirer from 'inquirer';
+
+import App from '../../lib/App.js';
+import NpmCommands from '../../lib/NpmCommands.js';
+import AthomApi from '../../services/AthomApi.js';
+import { copyFixtureApp } from './helpers.mjs';
+
+describe('new app build configuration', () => {
+  for (const language of ['javascript', 'typescript']) {
+    it(`sets an explicit build choice for ${language}`, async (t) => {
+      const cwd = await copyFixtureApp(t, 'node-basic');
+      t.mock.method(inquirer, 'prompt', async () => {
+        return { confirm: true, eslint: false, 'github-workflows': false };
+      });
+      t.mock.method(AthomApi, 'getProfile', async () => {
+        return { firstname: 'Test', lastname: 'Author', email: 'test@example.com' };
+      });
+      const install = t.mock.method(NpmCommands, 'installDev', async () => {});
+
+      await App.create({
+        appPath: cwd,
+        globalAnswers: {
+          id: 'com.test.created',
+          appName: 'Created App',
+          appDescription: 'An isolated app',
+          category: 'tools',
+          platforms: ['local'],
+          'programming-language': language,
+        },
+      });
+
+      const appPath = path.join(cwd, 'com.test.created');
+      const pkg = JSON.parse(await fs.readFile(path.join(appPath, 'package.json'), 'utf8'));
+      const installed = install.mock.calls.flatMap((call) => {
+        return call.arguments[0];
+      });
+      assert.strictEqual(pkg.homey.build, language === 'typescript');
+      if (language === 'typescript') {
+        assert.strictEqual(pkg.scripts.build, 'tsc');
+        assert.ok(installed.includes('typescript'));
+        await fs.access(path.join(appPath, 'app.ts'));
+        const config = JSON.parse(await fs.readFile(path.join(appPath, 'tsconfig.json'), 'utf8'));
+        assert.strictEqual(config.compilerOptions.outDir, '.homeybuild/');
+      } else {
+        assert.strictEqual(pkg.scripts.build, undefined);
+        assert.strictEqual(pkg.main, 'app.js');
+        assert.ok(!installed.includes('typescript'));
+        await fs.access(path.join(appPath, 'app.js'));
+      }
+    });
+  }
+});

--- a/tests/app/templates.test.mjs
+++ b/tests/app/templates.test.mjs
@@ -1,0 +1,174 @@
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import App from '../../lib/App.js';
+import { copyFixtureApp } from './helpers.mjs';
+
+const templatePath = fileURLToPath(new URL('../../assets/templates/app/drivers/', import.meta.url));
+
+describe('driver template source language', () => {
+  const cases = [
+    { name: 'JSDoc JavaScript', files: ['app.js'], typescript: '*', expected: '.js' },
+    { name: 'TypeScript without a compiler dependency', files: ['app.ts'], expected: '.ts' },
+    {
+      name: 'mixed sources with a compiler dependency',
+      files: ['app.ts', 'app.js'],
+      typescript: '*',
+      expected: '.ts',
+    },
+    {
+      name: 'mixed sources without a compiler dependency',
+      files: ['app.ts', 'app.js'],
+      expected: '.js',
+    },
+    {
+      name: 'absent sources with a compiler dependency',
+      files: [],
+      typescript: '*',
+      expected: '.ts',
+    },
+    { name: 'absent sources without a compiler dependency', files: [], expected: '.js' },
+    {
+      name: 'JavaScript main takes precedence',
+      files: ['src/start.cjs', 'app.ts'],
+      main: 'src/start.cjs',
+      typescript: '*',
+      expected: '.js',
+    },
+    {
+      name: 'TypeScript main takes precedence',
+      files: ['src/start.mts', 'app.js'],
+      main: 'src/start.mts',
+      expected: '.ts',
+    },
+    {
+      name: 'missing main falls back to source',
+      files: ['app.ts'],
+      main: 'missing.js',
+      expected: '.ts',
+    },
+    {
+      name: 'unrecognized main falls back to source',
+      files: ['start.txt', 'app.ts'],
+      main: 'start.txt',
+      expected: '.ts',
+    },
+    {
+      name: 'build output main is ignored',
+      files: ['.homeybuild/app.js', 'app.ts'],
+      main: './.homeybuild/app.js',
+      expected: '.ts',
+    },
+    {
+      name: 'normalized build output main is ignored',
+      files: ['.homeybuild/app.js', 'app.ts'],
+      main: 'src/../.homeybuild/app.js',
+      expected: '.ts',
+    },
+    {
+      name: 'similarly named source directory is allowed',
+      files: ['.homeybuild-source/start.ts', 'app.js'],
+      main: '.homeybuild-source/start.ts',
+      expected: '.ts',
+    },
+    {
+      name: 'multiple files of one language',
+      files: ['app.js', 'app.cjs'],
+      typescript: '*',
+      expected: '.js',
+    },
+  ];
+
+  for (const extension of ['js', 'mjs', 'cjs', 'ts', 'mts', 'cts']) {
+    const expected = extension.includes('ts') ? '.ts' : '.js';
+    cases.push({ name: `root app.${extension}`, files: [`app.${extension}`], expected });
+    cases.push({
+      name: `main with .${extension}`,
+      files: [`src/start.${extension}`],
+      main: `src/start.${extension}`,
+      expected,
+    });
+  }
+
+  for (const scenario of cases) {
+    for (const build of [false, true]) {
+      it(`${scenario.name}, build=${build}`, async (t) => {
+        const appPath = await copyFixtureApp(t, 'node-basic');
+        await fs.rm(path.join(appPath, 'app.js'));
+        for (const file of scenario.files) {
+          const filePath = path.join(appPath, file);
+          await fs.mkdir(path.dirname(filePath), { recursive: true });
+          await fs.writeFile(filePath, '// source');
+        }
+        await fs.writeFile(
+          path.join(appPath, 'package.json'),
+          JSON.stringify({
+            main: scenario.main,
+            homey: { build },
+            devDependencies: { typescript: scenario.typescript },
+          }),
+        );
+        const driverPath = path.join(appPath, 'drivers/new');
+        await fs.mkdir(driverPath, { recursive: true });
+
+        await new App(appPath).copyDriverAndDeviceTemplate(templatePath, driverPath);
+
+        assert.deepStrictEqual((await fs.readdir(driverPath)).sort(), [
+          `device${scenario.expected}`,
+          `driver${scenario.expected}`,
+        ]);
+        for (const name of ['driver', 'device']) {
+          assert.strictEqual(
+            await fs.readFile(path.join(driverPath, `${name}${scenario.expected}`), 'utf8'),
+            await fs.readFile(path.join(templatePath, `${name}${scenario.expected}`), 'utf8'),
+          );
+        }
+      });
+    }
+  }
+
+  it('uses source files when package.json is malformed', async (t) => {
+    const appPath = await copyFixtureApp(t, 'node-basic');
+    await fs.rename(path.join(appPath, 'app.js'), path.join(appPath, 'app.ts'));
+    await fs.writeFile(path.join(appPath, 'package.json'), '{');
+
+    assert.strictEqual(App.usesTypeScriptSource({ appPath }), true);
+  });
+
+  it('ignores directories named as entry files', async (t) => {
+    const appPath = await copyFixtureApp(t, 'node-basic');
+    await fs.mkdir(path.join(appPath, 'app.ts'));
+    await fs.writeFile(
+      path.join(appPath, 'package.json'),
+      JSON.stringify({ main: 'app.ts', devDependencies: { typescript: '*' } }),
+    );
+
+    assert.strictEqual(App.usesTypeScriptSource({ appPath }), false);
+  });
+
+  for (const build of [undefined, false, true]) {
+    it(`preserves ESM templates with TypeScript source and build=${build}`, async (t) => {
+      const appPath = await copyFixtureApp(t, 'node-basic');
+      await fs.rename(path.join(appPath, 'app.js'), path.join(appPath, 'app.ts'));
+      await fs.writeFile(
+        path.join(appPath, 'package.json'),
+        JSON.stringify({ type: 'module', homey: { build }, devDependencies: { typescript: '*' } }),
+      );
+      const driverPath = path.join(appPath, 'drivers/new');
+      await fs.mkdir(driverPath, { recursive: true });
+
+      await new App(appPath).copyDriverAndDeviceTemplate(templatePath, driverPath);
+
+      for (const name of ['driver', 'device']) {
+        assert.strictEqual(
+          await fs.readFile(path.join(driverPath, `${name}.js`), 'utf8'),
+          await fs.readFile(path.join(templatePath, `${name}.mjs`), 'utf8'),
+        );
+      }
+      assert.deepStrictEqual((await fs.readdir(driverPath)).sort(), ['device.js', 'driver.js']);
+    });
+  }
+});


### PR DESCRIPTION
JavaScript apps that install TypeScript only for JSDoc checking currently trigger compilation and TypeScript driver templates. Add a boolean `homey.build` setting in the app's `package.json` so apps can control their build step independently of their source language.

- `true` runs `npm run build` from the app directory without TypeScript-specific checks. Scripts write generated deployment files into the prepared `.homeybuild` directory.
- `false` skips the app build script while preserving Compose, source/dependency copying, and normal validation.
- Omitted settings retain legacy TypeScript dependency detection and configuration checks. Invalid explicit settings fail before preprocessing changes files.

Driver templates infer the source language from the entry file or root app files, with the existing dependency fallback and ESM branch preserved. New JavaScript apps set `homey.build: false`; new TypeScript apps set it to `true`. The README documents the build contract and JSDoc use case. Native TypeScript execution and a future opt-in default remain separate work.

Validation: all 323 tests pass with `npm run test:coverage`, including CI coverage thresholds. Focused fixtures cover real npm build execution, failures, legacy configuration checks, preprocessing, templates, and scaffolding. `npm run lint` and `npm run prettier:check` also pass.
