### PR TITLE
fix(publish): only ask to confirm App Store guidelines once

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -1393,7 +1393,7 @@ $ sudo systemctl restart docker
         }
       }
 
-      if (process.env.HOMEY_HEADLESS !== '1') {
+      if (process.env.HOMEY_HEADLESS !== '1' && !(await Settings.get('hasReadGuidelines'))) {
         Log('');
         Log.info('Before publishing, please review the Homey App Store guidelines:');
         Log.info('https://apps.developer.homey.app/app-store/guidelines');
@@ -1407,6 +1407,7 @@ $ sudo systemctl restart docker
           },
         ]);
         if (!hasReadGuidelines) return;
+        await Settings.set('hasReadGuidelines', true);
       }
 
       let manifest = App.getManifest({ appPath: this.path });


### PR DESCRIPTION
`homey app publish` asked "I have read the Homey App Store guidelines" on every publish, which is noise for developers who publish often.

The confirmation is now persisted in the CLI settings (`~/.athom-cli/settings.json`, key `hasReadGuidelines`), so the guidelines URL and the prompt are shown once per machine. Declining still aborts the publish and stores nothing, so the prompt returns on the next attempt. Headless publishes are unaffected.

Validation: `npm run lint` and `npm run prettier:check` pass. `npm test` shows 161 pass / 3 fail; those 3 completion tests fail identically on `develop` without this change.