### PR TITLE
perf(cli): Probe USB Homey candidates in parallel

### DIFF
--- a/lib/AthomApi.js
+++ b/lib/AthomApi.js
@@ -188,29 +188,35 @@ class AthomApi {
     // find USB connected Homeys
     if (local) {
       const ifaces = os.networkInterfaces();
+      const candidateIps = new Set();
 
       for (const adapters of Object.values(ifaces)) {
         for (const adapter of Object.values(adapters)) {
-          try {
-            let ip = adapter.address.split('.');
-            if (ip[0] !== '10') continue;
-            ip[3] = '1';
-            ip = ip.join('.');
+          const octets = adapter.address?.split('.') ?? [];
+          if (octets.length !== 4 || octets[0] !== '10') continue;
+          octets[3] = '1';
+          candidateIps.add(octets.join('.'));
+        }
+      }
 
+      // Probe concurrently: every candidate that is not a Homey costs the full timeout.
+      await Promise.all(
+        [...candidateIps].map(async (ip) => {
+          try {
             const res = await fetch(`http://${ip}/api/manager/webserver/ping`, {
               signal: AbortSignal.timeout(1000),
             });
 
             const homeyId = res.headers.get('x-homey-id');
-            if (!homeyId) continue;
+            if (!homeyId) return;
 
             const homey = this._homeys.find((candidate) => candidate.id === homeyId);
             if (homey) {
               homey.usb = ip;
             }
           } catch (err) {}
-        }
-      }
+        }),
+      );
     }
 
     return this._homeys;

--- a/tests/lib/athom-api.fetch.test.mjs
+++ b/tests/lib/athom-api.fetch.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import os from 'node:os';
 import { afterEach, describe, it, mock } from 'node:test';
+import { setImmediate } from 'node:timers/promises';
 
 import AthomApi from '../../lib/AthomApi.js';
 
@@ -58,6 +59,48 @@ describe('AthomApi local discovery fetch behavior', () => {
     const result = await athomApi.getHomeys({ cache: false, local: true });
 
     assert.strictEqual(result[0].usb, undefined);
+  });
+
+  it('probes one address per subnet, all at the same time', async () => {
+    const athomApi = new AthomApi();
+    const homeys = [{ id: 'homey-1', name: 'Homey One' }];
+
+    athomApi._user = {
+      getHomeys: async () => homeys,
+    };
+
+    mock.method(athomApi, '_initApi', async () => {});
+    mock.method(os, 'networkInterfaces', () => ({
+      en0: [{ address: '10.211.55.2' }, { address: 'fe80::1' }],
+      vnic1: [{ address: '10.211.55.3' }],
+      vnic2: [{ address: '10.37.129.2' }],
+      lo: [{ address: '127.0.0.1' }],
+    }));
+
+    // Hold every probe open so a sequential implementation cannot reach the second one.
+    const inflight = [];
+    mock.method(
+      global,
+      'fetch',
+      (url) => new Promise((resolve) => inflight.push({ url, resolve })),
+    );
+
+    const pending = athomApi.getHomeys({ cache: false, local: true });
+    await setImmediate();
+
+    try {
+      assert.deepStrictEqual(inflight.map(({ url }) => url).sort(), [
+        'http://10.211.55.1/api/manager/webserver/ping',
+        'http://10.37.129.1/api/manager/webserver/ping',
+      ]);
+    } finally {
+      for (const { resolve } of inflight) {
+        resolve({ headers: { get: () => null } });
+      }
+    }
+
+    await pending;
+    assert.strictEqual(inflight.length, 2);
   });
 
   it('continues when local ping fetch fails', async () => {


### PR DESCRIPTION
## What

Local Homey discovery probes its candidate USB addresses concurrently, and only once per subnet.

## Why

`getHomeys()` looks for a USB-connected Homey by pinging `10.x.y.1` for every network interface whose address starts with `10.`. Those probes ran one after another with a one second timeout each, so every such interface that is not a Homey added a full second to any command that has to resolve a Homey first, including `homey api ...`, `homey list` and `homey select`.

Virtualization tools routinely add a couple of `10.x` adapters to a machine, and none of them ever answer. Two interfaces in the same subnet made it worse: both map to the same candidate address, so that address was probed twice, each time for the full timeout.

## How

Collect the unique candidate addresses first, then run the probes with `Promise.all`. The timeout, the request and the id matching are unchanged, so the cost is now bounded by the one second timeout instead of scaling with the number of interfaces.

## Testing

Measured with `os.networkInterfaces` stubbed to report dead `10.x` adapters and the rest of `getHomeys` stubbed out:

| interfaces | before | after |
| --- | --- | --- |
| 4, two of them in one subnet | 4006ms, 4 probes | 1004ms, 3 probes |
| 8 | 9012ms | 1005ms |

End to end on a machine with three such interfaces (two from a virtualization tool, one from a VPN tunnel), running `homey api raw --path /api/manager/system/` against a real Homey over the cloud strategy: 3.05s, 3.12s, 3.14s before, 1.94s, 1.97s, 1.99s after.

- `tests/lib/athom-api.fetch.test.mjs` gains a case that holds every probe open until all of them have started, so a sequential implementation cannot reach the second address. It fails on the previous implementation and needs no timers.
- Full suite: 233 passing, with the same 6 pre-existing environment-dependent failures as on `develop` (Docker host address and completion fixtures).
- `eslint --max-warnings=0` and `prettier --check` are clean.
